### PR TITLE
Implementation of an XPRA Logger

### DIFF
--- a/zcl_logger.clas.abap
+++ b/zcl_logger.clas.abap
@@ -60,6 +60,8 @@ class zcl_logger definition
   protected section.
 *"* protected components of class ZCL_LOGGER
 *"* do not include other source files here!!!
+    methods save_log.
+
   private section.
 * Local type for hrpad_message as it is not available in an ABAP Development System
     types: begin of hrpad_message_field_list_alike,
@@ -108,8 +110,6 @@ class zcl_logger definition
             preferred parameter obj_to_log
         returning
           value(self)   type ref to zif_logger .
-
-    methods save_log.
 endclass.
 
 

--- a/zcl_logger_factory.clas.abap
+++ b/zcl_logger_factory.clas.abap
@@ -35,69 +35,52 @@ class zcl_logger_factory definition
 
   protected section.
   private section.
-ENDCLASS.
+    "! Name of background job which executes XPRA reports
+    constants xpra_job_name type btcjob value 'RDDEXECL'.
+
+    "! True if current execution environment is as an XPRA report
+    class-methods is_executing_as_xpra
+      returning
+        value(result) type abap_bool.
+    "! Create application log logger
+    class-methods create_sbal_logger
+      importing
+        !object       type csequence optional
+        !subobject    type csequence optional
+        !desc         type csequence optional
+        !context      type simple optional
+        !settings     type ref to zif_logger_settings
+      returning
+        value(result) type ref to zif_logger.
+    "! Create XPRA logger
+    class-methods create_xpra_logger
+      importing
+        !settings     type ref to zif_logger_settings
+      returning 
+        value(result) type ref to zif_logger.
+endclass.
 
 
-
-CLASS ZCL_LOGGER_FACTORY IMPLEMENTATION.
-
+class zcl_logger_factory implementation.
 
   method create_log.
+    data logger_settings type ref to zif_logger_settings.
 
-    data: lo_log type ref to zcl_logger.
-    field-symbols <context_val> type c.
-
-    create object lo_log.
-    lo_log->header-object    = object.
-    lo_log->header-subobject = subobject.
-    lo_log->header-extnumber = desc.
-
-    if settings is bound.
-      lo_log->settings = settings.
+    if settings is bound and settings is not initial.
+      logger_settings = settings.
     else.
-      create object lo_log->settings type zcl_logger_settings.
+      logger_settings = create_settings( ).
     endif.
 
-* Special case: Logger can work without object - but then
-* the data cannot be written to the database.
-    if object is initial.
-      lo_log->settings->set_autosave( abap_false ).
+    if is_executing_as_xpra( ) = abap_true.
+      r_log = create_xpra_logger( settings = logger_settings ).
+    else.
+      r_log = create_sbal_logger( object    = object
+                                  subobject = subobject
+                                  desc      = desc
+                                  context   = context
+                                  settings  = logger_settings ).
     endif.
-
-* Use secondary database connection to write data to database even if
-* main program does a rollback (e. g. during a dump).
-    if lo_log->settings->get_usage_of_secondary_db_conn( ) = abap_true.
-      lo_log->sec_connection     = abap_true.
-      lo_log->sec_connect_commit = abap_true.
-    endif.
-
-* Set deletion date and set if log can be deleted before deletion date is reached.
-    lo_log->header-aldate_del = lo_log->settings->get_expiry_date( ).
-    lo_log->header-del_before = lo_log->settings->get_must_be_kept_until_expiry( ).
-
-    if context is supplied and context is not initial.
-      lo_log->header-context-tabname =
-        cl_abap_typedescr=>describe_by_data( context )->get_ddic_header( )-tabname.
-      assign context to <context_val> casting.
-      lo_log->header-context-value = <context_val>.
-    endif.
-
-    call function 'BAL_LOG_CREATE'
-      exporting
-        i_s_log      = lo_log->header
-      importing
-        e_log_handle = lo_log->handle.
-
-* BAL_LOG_CREATE will fill in some additional header data.
-* This FM updates our instance attribute to reflect that.
-    call function 'BAL_LOG_HDR_READ'
-      exporting
-        i_log_handle = lo_log->handle
-      importing
-        e_s_log      = lo_log->header.
-
-    r_log = lo_log.
-
   endmethod.
 
 
@@ -179,4 +162,92 @@ CLASS ZCL_LOGGER_FACTORY IMPLEMENTATION.
     r_log = lo_log.
 
   endmethod.
-ENDCLASS.
+
+
+  method is_executing_as_xpra.
+*   XPRA executes in client 000 in a specific job
+    data current_job_name type btcjob.
+
+    result = abap_false.
+    if sy-mandt <> '000'.
+      return.
+    endif.
+
+    call function 'GET_JOB_RUNTIME_INFO'
+      importing
+        jobname         = current_job_name
+      exceptions
+        no_runtime_info = 1.
+    if sy-subrc <> 0.
+      return.
+    elseif current_job_name = xpra_job_name.
+      result = abap_true.
+    endif.
+  endmethod.
+
+
+  method create_xpra_logger.
+    data xpra_logger type ref to zcl_logger_xpra.
+
+*   Always autosave XPRA logs
+    settings->set_autosave( abap_true ).
+
+    create object xpra_logger.
+    xpra_logger->settings = settings.
+    result = xpra_logger.
+  endmethod.
+
+
+  method create_sbal_logger.
+    data: lo_log type ref to zcl_logger.
+    field-symbols <context_val> type c.
+
+    create object lo_log.
+    lo_log->header-object    = object.
+    lo_log->header-subobject = subobject.
+    lo_log->header-extnumber = desc.
+
+    lo_log->settings = settings.
+
+* Special case: Logger can work without object - but then
+* the data cannot be written to the database.
+    if object is initial.
+      lo_log->settings->set_autosave( abap_false ).
+    endif.
+
+* Use secondary database connection to write data to database even if
+* main program does a rollback (e. g. during a dump).
+    if lo_log->settings->get_usage_of_secondary_db_conn( ) = abap_true.
+      lo_log->sec_connection     = abap_true.
+      lo_log->sec_connect_commit = abap_true.
+    endif.
+
+* Set deletion date and set if log can be deleted before deletion date is reached.
+    lo_log->header-aldate_del = lo_log->settings->get_expiry_date( ).
+    lo_log->header-del_before = lo_log->settings->get_must_be_kept_until_expiry( ).
+
+    if context is supplied and context is not initial.
+      lo_log->header-context-tabname =
+        cl_abap_typedescr=>describe_by_data( context )->get_ddic_header( )-tabname.
+      assign context to <context_val> casting.
+      lo_log->header-context-value = <context_val>.
+    endif.
+
+    call function 'BAL_LOG_CREATE'
+      exporting
+        i_s_log      = lo_log->header
+      importing
+        e_log_handle = lo_log->handle.
+
+* BAL_LOG_CREATE will fill in some additional header data.
+* This FM updates our instance attribute to reflect that.
+    call function 'BAL_LOG_HDR_READ'
+      exporting
+        i_log_handle = lo_log->handle
+      importing
+        e_s_log      = lo_log->header.
+
+    result = lo_log.
+  endmethod.
+
+endclass.

--- a/zcl_logger_xpra.clas.abap
+++ b/zcl_logger_xpra.clas.abap
@@ -1,0 +1,71 @@
+class zcl_logger_xpra definition
+  public
+  inheriting from zcl_logger
+  create protected
+
+  global friends zcl_logger_factory .
+
+  public section.
+    methods constructor .
+
+  protected section.
+    methods save_log redefinition.
+
+  private section.
+
+endclass.
+
+
+class zcl_logger_xpra implementation.
+
+  method constructor.
+*   Create an application log (memory only) to store messages until they are saved to the database
+    super->constructor( ).
+    call function 'BAL_LOG_CREATE'
+      exporting
+        i_s_log      = zif_logger~header
+      importing
+        e_log_handle = zif_logger~handle.
+    call function 'BAL_LOG_HDR_READ'
+      exporting
+        i_log_handle = zif_logger~handle
+      importing
+        e_s_log      = zif_logger~header.
+  endmethod.
+
+
+  method save_log.
+    data log_messages type standard table of sprot_u with default key.
+    data message_handles type bal_t_msgh.
+    data message type bal_s_msg.
+    field-symbols <msg_handle> type balmsghndl.
+
+    message_handles = get_message_handles( ).
+    loop at message_handles assigning <msg_handle>.
+      call function 'BAL_LOG_MSG_READ'
+        exporting
+          i_s_msg_handle = <msg_handle>
+        importing
+          e_s_msg        = message
+        exceptions
+          others         = 3.
+      if sy-subrc is initial.
+        append map_from_application_log_messg( message ) to log_messages.
+      endif.
+    endloop.
+    call function 'TR_APPEND_LOG'
+      tables
+        xmsg           = log_messages
+      exceptions
+        file_not_found = 1
+        wrong_call     = 2.
+    if sy-subrc = 0.
+      call function 'BAL_LOG_MSG_DELETE_ALL'
+        exporting
+          i_log_handle  = zif_logger~handle
+        exceptions
+          log_not_found = 0.
+    endif.
+  endmethod.
+
+endclass.

--- a/zcl_logger_xpra.clas.xml
+++ b/zcl_logger_xpra.clas.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCL_LOGGER_XPRA</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>Logger for XPRA reports - add messages to transport log</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>


### PR DESCRIPTION
Reports executed during transport import (XPRA transport object) would create application logs in client zero. Instead of saving an inaccessible application log, this logger will write the log messages to the transport log.
The implementation essentially only re-implements the save_log method.

I've based it on the fix for logging table of BAPI messages since the save_log method was defined in that fix.