### PR TITLE
Context not being used when logging a table of messages

### DIFF
--- a/zcl_logger.clas.abap
+++ b/zcl_logger.clas.abap
@@ -377,7 +377,10 @@ class zcl_logger implementation.
     elseif msg_type->type_kind = cl_abap_typedescr=>typekind_table.
       assign obj_to_log to <table_of_messages>.
       loop at <table_of_messages> assigning <message_line>.
-        add( <message_line> ).
+        add(
+          EXPORTING
+            obj_to_log    = <message_line>
+            context       = context
       endloop.
     elseif msg_type->type_kind = cl_abap_typedescr=>typekind_struct1   "flat structure
         or msg_type->type_kind = cl_abap_typedescr=>typekind_struct2.  "deep structure (already when string is used)


### PR DESCRIPTION
When passing a table of messages to the ADD method, the context was not being used for the individual messages in the table.