### PR TITLE
Add exception class for transport logger

### DIFF
--- a/zcx_static_check_with_log.clas.abap
+++ b/zcx_static_check_with_log.clas.abap
@@ -1,0 +1,32 @@
+class ZCX_STATIC_CHECK_WITH_LOG definition
+  public
+  inheriting from CX_STATIC_CHECK
+  create public .
+
+public section.
+
+  data LOGGER type ref to ZIF_LOGGER read-only .
+
+  methods CONSTRUCTOR
+    importing
+      !TEXTID like TEXTID optional
+      !PREVIOUS like PREVIOUS optional
+      !LOGGER type ref to ZIF_LOGGER .
+protected section.
+private section.
+ENDCLASS.
+
+
+
+CLASS ZCX_STATIC_CHECK_WITH_LOG IMPLEMENTATION.
+
+
+  method CONSTRUCTOR.
+CALL METHOD SUPER->CONSTRUCTOR
+EXPORTING
+TEXTID = TEXTID
+PREVIOUS = PREVIOUS
+.
+me->LOGGER = LOGGER .
+  endmethod.
+ENDCLASS.

--- a/zcx_static_check_with_log.clas.xml
+++ b/zcx_static_check_with_log.clas.xml
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCX_STATIC_CHECK_WITH_LOG</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>Exception with inner log</DESCRIPT>
+    <CATEGORY>40</CATEGORY>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+   <DESCRIPTIONS>
+    <SEOCOMPOTX>
+     <CLSNAME>ZCX_STATIC_CHECK_WITH_LOG</CLSNAME>
+     <CMPNAME>CONSTRUCTOR</CMPNAME>
+     <LANGU>E</LANGU>
+     <DESCRIPT>CONSTRUCTOR</DESCRIPT>
+    </SEOCOMPOTX>
+   </DESCRIPTIONS>
+  </asx:values>
+ </asx:abap>
+</abapGit>


### PR DESCRIPTION
Exception class to transport a logger object is added. Quite useful when error log is generated in backend and displayed in the frontend.