### PR TITLE
Update zcl_logger.clas.locals_def.abap

### DIFF
--- a/zcl_logger.clas.locals_def.abap
+++ b/zcl_logger.clas.locals_def.abap
@@ -8,4 +8,4 @@ types: begin of ty_exception,
        end of ty_exception,
        tty_exception type standard table of ty_exception.
 
-types: tty_exception_data    type standard table of bal_s_exc with default key.
+types: tty_exception_data    type standard table of bal_s_exc with empty key.


### PR DESCRIPTION
Replaces "with default key" by "with empy key"
https://github.com/SAP/styleguides/blob/master/clean-abap/CleanABAP.md#avoid-default-key