### PR TITLE
Fixed language "E" to sy-langu

### DIFF
--- a/src/zcl_logger.clas.testclasses.abap
+++ b/src/zcl_logger.clas.testclasses.abap
@@ -1225,7 +1225,7 @@ class lcl_test implementation.
     call function 'FORMAT_MESSAGE'
       exporting
         id        = id
-        lang      = 'E'
+        lang      = sy-langu
         no        = no
         v1        = v1
         v2        = v2


### PR DESCRIPTION
unit test "can_log_batch_msgs" and "can_log_chained_exceptions" are failing when not sy-langu <> 'E'