### PR TITLE
added symsg

### DIFF
--- a/src/zcl_logger.clas.abap
+++ b/src/zcl_logger.clas.abap
@@ -260,6 +260,7 @@ class zcl_logger implementation.
 
     field-symbols: <table_of_messages> type any table,
                    <message_line>      type any,
+                   <symsg>             TYPE symsg,
                    <bapiret1_msg>      type bapiret1,
                    <bapi_msg>          type bapiret2,
                    <bapi_coru_msg>     type bapi_coru_return,
@@ -309,6 +310,15 @@ class zcl_logger implementation.
       detailed_msg-msgv2 = sy-msgv2.
       detailed_msg-msgv3 = sy-msgv3.
       detailed_msg-msgv4 = sy-msgv4.
+    elseif msg_type->absolute_name = '\TYPE=SYMSG'.
+      assign obj_to_log to <symsg>.
+      detailed_msg-msgty = <symsg>-msgty.
+      detailed_msg-msgid = <symsg>-msgid.
+      detailed_msg-msgno = <symsg>-msgno.
+      detailed_msg-msgv1 = <symsg>-msgv1.
+      detailed_msg-msgv2 = <symsg>-msgv2.
+      detailed_msg-msgv3 = <symsg>-msgv3.
+      detailed_msg-msgv4 = <symsg>-msgv4.
     elseif msg_type->absolute_name = '\TYPE=BAPIRET1'.
       assign obj_to_log to <bapiret1_msg>.
       detailed_msg-msgty = <bapiret1_msg>-type.
@@ -378,7 +388,7 @@ elseif msg_type->absolute_name = '\TYPE=BAPI_ORDER_RETURN'.
       endif.
       exception_data_table = me->drill_down_into_exception(
           exception   = obj_to_log
-          type        = message_type       
+          type        = message_type
           importance  = importance
           ).
     elseif msg_type->type_kind = cl_abap_typedescr=>typekind_table.

--- a/src/zcl_logger.clas.testclasses.abap
+++ b/src/zcl_logger.clas.testclasses.abap
@@ -51,6 +51,7 @@ class lcl_test definition for testing
 
       can_log_string for testing,
       can_log_char   for testing,
+      can_log_symsg for testing,
       can_log_bapiret1  for testing,
       can_log_bapiret2  for testing,
       can_log_bapi_coru_return for testing,
@@ -349,6 +350,58 @@ class lcl_test implementation.
       exp = charmessage
       act = get_first_message( anon_log->handle )
       msg = 'Did not log system message properly' ).
+  endmethod.
+
+  method can_log_symsg.
+    data: symsg            type symsg,
+          msg_handle       type balmsghndl,
+          expected_details type bal_s_msg,
+          actual_details   type bal_s_msg,
+          actual_text      type char200.
+
+    expected_details-msgty = symsg-msgty = 'W'.
+    expected_details-msgid = symsg-msgid = 'BL'.
+    expected_details-msgno = symsg-msgno = '001'.
+    expected_details-msgv1 = symsg-msgv1 = 'This'.
+    expected_details-msgv2 = symsg-msgv2 = 'is'.
+    expected_details-msgv3 = symsg-msgv3 = 'a'.
+    expected_details-msgv4 = symsg-msgv4 = 'test'.
+
+    anon_log->add( symsg ).
+
+    msg_handle-log_handle = anon_log->handle.
+    msg_handle-msgnumber  = '000001'.
+
+    call function 'BAL_LOG_MSG_READ'
+      exporting
+        i_s_msg_handle = msg_handle
+      importing
+        e_s_msg        = actual_details
+        e_txt_msg      = actual_text.
+
+    cl_aunit_assert=>assert_not_initial(
+      act = actual_details-time_stmp
+      msg = 'Did not log system message properly' ).
+
+    expected_details-msg_count = 1.
+    clear actual_details-time_stmp.
+
+    cl_aunit_assert=>assert_equals(
+      exp = expected_details
+      act = actual_details
+      msg = 'Did not log system message properly' ).
+
+    cl_aunit_assert=>assert_equals(
+      exp = 'This is a test'
+      act = condense( actual_text )
+      msg = 'Did not log system message properly' ).
+
+    cl_aunit_assert=>assert_equals(
+      exp = abap_true
+      act = anon_log->has_warnings( )
+      msg = 'Did not log or fetch system message properly'
+    ).
+
   endmethod.
 
   method can_log_bapiret1.


### PR DESCRIPTION
I needed the possibility to log messages from **CMD_BS_MAT_S_MAT_MSG**.
To keep it as general as possible I added the structure **symsg**,
so logging is achieved by:
`logger->add( CORRESPONDING symsg_tab( messages ) ).`
