### PR TITLE
new setter for description (EXTNUMBER)

### DIFF
--- a/src/zcl_logger.clas.abap
+++ b/src/zcl_logger.clas.abap
@@ -744,4 +744,24 @@ CLASS zcl_logger IMPLEMENTATION.
       me->db_number = log_number-lognumber.
     ENDIF.
   ENDMETHOD.
+
+
+  METHOD zif_logger~set_desc.
+
+    me->header-extnumber = desc.
+
+    CALL FUNCTION 'BAL_LOG_HDR_CHANGE'
+      EXPORTING
+        i_log_handle            = me->handle
+        i_s_log                 = header
+      EXCEPTIONS
+        log_not_found           = 1
+        log_header_inconsistent = 2
+        OTHERS                  = 3.
+    ASSERT sy-subrc = 0.
+
+    self = me.
+
+  ENDMETHOD.
+
 ENDCLASS.

--- a/src/zcl_logger.clas.abap
+++ b/src/zcl_logger.clas.abap
@@ -746,9 +746,9 @@ CLASS zcl_logger IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD zif_logger~set_desc.
+  METHOD zif_logger~set_header.
 
-    me->header-extnumber = desc.
+    me->header-extnumber = description.
 
     CALL FUNCTION 'BAL_LOG_HDR_CHANGE'
       EXPORTING

--- a/src/zcl_logger.clas.testclasses.abap
+++ b/src/zcl_logger.clas.testclasses.abap
@@ -96,7 +96,7 @@ CLASS lcl_test DEFINITION FOR TESTING
       return_proper_length FOR TESTING,
       can_add_table_msg_context FOR TESTING RAISING cx_static_check,
 
-      can_change_desc FOR TESTING RAISING cx_static_check.
+      can_change_description FOR TESTING RAISING cx_static_check.
 
 ENDCLASS.       "lcl_Test
 
@@ -1467,7 +1467,7 @@ CLASS lcl_test IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD can_change_desc.
+  METHOD can_change_description.
 
     DATA desc TYPE bal_s_log-extnumber.
 
@@ -1477,7 +1477,7 @@ CLASS lcl_test IMPLEMENTATION.
                                  subobject = 'LOGGER'
                                  auto_save = abap_false ).
 
-    named_log->set_desc( desc ).
+    named_log->set_header( desc ).
 
     cl_abap_unit_assert=>assert_equals(
         exp = desc

--- a/src/zcl_logger.clas.testclasses.abap
+++ b/src/zcl_logger.clas.testclasses.abap
@@ -94,7 +94,9 @@ CLASS lcl_test DEFINITION FOR TESTING
 
       return_proper_status FOR TESTING,
       return_proper_length FOR TESTING,
-      can_add_table_msg_context FOR TESTING RAISING cx_static_check.
+      can_add_table_msg_context FOR TESTING RAISING cx_static_check,
+
+      can_change_desc FOR TESTING RAISING cx_static_check.
 
 ENDCLASS.       "lcl_Test
 
@@ -1461,6 +1463,42 @@ CLASS lcl_test IMPLEMENTATION.
       exp = 3
       act = anon_log->length( )
       msg = 'Did not return right length after add' ).
+
+  ENDMETHOD.
+
+
+  METHOD can_change_desc.
+
+    DATA desc TYPE bal_s_log-extnumber.
+
+    desc = cl_system_uuid=>create_uuid_c32_static( ).
+
+    named_log = zcl_logger=>new( object    = 'ABAPUNIT'
+                                 subobject = 'LOGGER'
+                                 auto_save = abap_false ).
+
+    named_log->set_desc( desc ).
+
+    cl_abap_unit_assert=>assert_equals(
+        exp = desc
+        act = named_log->header-extnumber
+        msg = 'Did not return new desc' ).
+
+    named_log->save( ).
+
+    CALL FUNCTION 'BAL_GLB_MEMORY_REFRESH'.                "Close Logs
+    reopened_log = zcl_logger=>open( object    = 'ABAPUNIT'
+                                     subobject = 'LOGGER'
+                                     desc      = desc ).
+
+    cl_abap_unit_assert=>assert_bound(
+        act = reopened_log
+        msg = 'Did not find log with new desc' ).
+
+    cl_abap_unit_assert=>assert_equals(
+        exp = desc
+        act = reopened_log->header-extnumber
+        msg = 'Did not return new desc' ).
 
   ENDMETHOD.
 

--- a/src/zif_logger.intf.abap
+++ b/src/zif_logger.intf.abap
@@ -111,4 +111,10 @@ INTERFACE zif_logger
     IMPORTING
       profile TYPE bal_s_prof OPTIONAL.
 
+  METHODS set_desc
+    IMPORTING
+      desc        TYPE bal_s_log-extnumber
+    RETURNING
+      VALUE(self) TYPE REF TO zif_logger .
+
 ENDINTERFACE.

--- a/src/zif_logger.intf.abap
+++ b/src/zif_logger.intf.abap
@@ -111,9 +111,9 @@ INTERFACE zif_logger
     IMPORTING
       profile TYPE bal_s_prof OPTIONAL.
 
-  METHODS set_desc
+  METHODS set_header
     IMPORTING
-      desc        TYPE bal_s_log-extnumber
+      description TYPE bal_s_log-extnumber
     RETURNING
       VALUE(self) TYPE REF TO zif_logger .
 


### PR DESCRIPTION
With this change it's possible to change the external number after the log is instantiated. This is especially useful e.g. if EXTNUMBER should be a document number which is created in some business process after log instantiation.