### PR TITLE
Remove whitespace at end of line

### DIFF
--- a/src/zcl_logger.clas.testclasses.abap
+++ b/src/zcl_logger.clas.testclasses.abap
@@ -1481,8 +1481,8 @@ CLASS lcl_test IMPLEMENTATION.
       act = lines( table )
       msg = 'Did not log system message properly' ).
   ENDMETHOD.
-  
-  
+
+
   METHOD can_change_description.
 
     DATA desc TYPE bal_s_log-extnumber.


### PR DESCRIPTION
Fixes diff after pull

![saplogon_882](https://user-images.githubusercontent.com/59966492/175065185-768a4da9-4f35-4147-9b68-b0579be187cd.png)

(related https://github.com/abapGit/abapGit/pull/5643)

To avoid future cases, 
- enable abaplint rule `whitespace_end`
- provide `.editorconfig` file