### PR TITLE
Fixes some ATC warnings

### DIFF
--- a/src/zcl_logger.clas.abap
+++ b/src/zcl_logger.clas.abap
@@ -539,7 +539,7 @@ CLASS zcl_logger IMPLEMENTATION.
 
     msg_struct_type ?= cl_abap_typedescr=>describe_by_data( obj_to_log ).
     components = msg_struct_type->components.
-    add( '--- Begin of structure ---' ).
+    add( '--- Begin of structure ---' ##NO_TEXT ).
     LOOP AT components INTO component.
       ASSIGN COMPONENT component-name OF STRUCTURE obj_to_log TO <component>.
       IF sy-subrc = 0.
@@ -563,7 +563,7 @@ CLASS zcl_logger IMPLEMENTATION.
         ENDIF.
       ENDIF.
     ENDLOOP.
-    add( '--- End of structure ---' ).
+    add( '--- End of structure ---' ##NO_TEXT ).
   ENDMETHOD.
 
 
@@ -626,7 +626,7 @@ CLASS zcl_logger IMPLEMENTATION.
           profile        TYPE bal_s_prof,
           lt_log_handles TYPE bal_t_logh.
 
-    APPEND me->handle TO lt_log_handles.
+    INSERT me->handle INTO TABLE lt_log_handles.
 
     CALL FUNCTION 'BAL_DSP_PROFILE_SINGLE_LOG_GET'
       IMPORTING
@@ -685,7 +685,7 @@ CLASS zcl_logger IMPLEMENTATION.
     DATA relevant_profile TYPE bal_s_prof.
     DATA lt_log_handles   TYPE bal_t_logh.
 
-    APPEND me->handle TO lt_log_handles.
+    INSERT me->handle INTO TABLE lt_log_handles.
 
     IF profile IS SUPPLIED AND profile IS NOT INITIAL.
       relevant_profile = profile.

--- a/src/zcl_logger.clas.testclasses.abap
+++ b/src/zcl_logger.clas.testclasses.abap
@@ -277,7 +277,7 @@ CLASS lcl_test IMPLEMENTATION.
   METHOD can_add_to_log.
     DATA: dummy TYPE c.
 
-    MESSAGE s001(00) WITH 'I' 'test' 'the' 'logger.' INTO dummy.
+    MESSAGE s001(00) WITH 'I' 'test' 'the' 'logger.' INTO dummy ##MG_MISSING.
     anon_log->add( ).
 
     cl_aunit_assert=>assert_equals(
@@ -290,7 +290,7 @@ CLASS lcl_test IMPLEMENTATION.
   METHOD can_add_to_named_log.
     DATA: dummy TYPE c.
 
-    MESSAGE s001(00) WITH 'Testing' 'a' 'named' 'logger.' INTO dummy.
+    MESSAGE s001(00) WITH 'Testing' 'a' 'named' 'logger.' INTO dummy ##MG_MISSING.
     named_log->add( ).
 
     cl_aunit_assert=>assert_equals(
@@ -311,7 +311,7 @@ CLASS lcl_test IMPLEMENTATION.
 
     CALL FUNCTION 'BAL_GLB_MEMORY_REFRESH'.
 
-    APPEND named_log->db_number TO log_numbers.
+    INSERT named_log->db_number INTO TABLE log_numbers.
     CALL FUNCTION 'BAL_DB_LOAD'
       EXPORTING
         i_t_lognumber = log_numbers.
@@ -330,7 +330,7 @@ CLASS lcl_test IMPLEMENTATION.
     reopened_log->add( 'This is another message in the database' ).
     CALL FUNCTION 'BAL_GLB_MEMORY_REFRESH'.
 
-    APPEND reopened_log->db_number TO log_numbers.
+    INSERT reopened_log->db_number INTO TABLE log_numbers.
     CALL FUNCTION 'BAL_DB_LOAD'
       EXPORTING
         i_t_lognumber = log_numbers.
@@ -1157,7 +1157,7 @@ CLASS lcl_test IMPLEMENTATION.
     DATA dummy            TYPE string.
     CREATE OBJECT loggable TYPE ltd_loggable_object.
 
-    MESSAGE s001(00) WITH 'I' 'test' 'the' 'logger.' INTO dummy.
+    MESSAGE s001(00) WITH 'I' 'test' 'the' 'logger.' INTO dummy ##MG_MISSING.
     MOVE-CORRESPONDING sy TO loggable_message-symsg.
     loggable_message-type = sy-msgty.
     APPEND loggable_message TO loggable->messages.
@@ -1372,7 +1372,7 @@ CLASS lcl_test IMPLEMENTATION.
           msg_detail      TYPE bal_s_msg,
           msg_text        TYPE char255.
 
-    APPEND log_handle TO handle_as_table.
+    INSERT log_handle INTO TABLE handle_as_table.
     CALL FUNCTION 'BAL_GLB_SEARCH_MSG'
       EXPORTING
         i_t_log_handle = handle_as_table


### PR DESCRIPTION
removing some smoke, so we can focus on the more important ATC warnings:
following changes were made

1. replace APPEND with INSERT for sorted tables (ATC: CL_CI_TEST_APPEND_TO_SORTED)
2. added some PRAGMAs (##MG_MISSING and ##NO_TEXT) to remove other ATC warnings, where I believe the solution is already good.