### PR TITLE
class for display profile

### DIFF
--- a/src/zcl_logger_display_profile.clas.abap
+++ b/src/zcl_logger_display_profile.clas.abap
@@ -70,12 +70,15 @@ CLASS ZCL_LOGGER_DISPLAY_PROFILE IMPLEMENTATION.
 
     CHECK display_profile IS NOT INITIAL.
 
-    DATA colpos    TYPE i VALUE 100.
-    DATA sortpos   TYPE i VALUE 1.
-    DATA mess_fcat LIKE LINE OF display_profile-mess_fcat.
-    DATA component TYPE cl_abap_structdescr=>component.
+    DATA colpos     TYPE i VALUE 100.
+    DATA sortpos    TYPE i VALUE 1.
+    DATA mess_fcat  LIKE LINE OF display_profile-mess_fcat.
+    DATA component  TYPE cl_abap_structdescr=>component.
+    DATA components TYPE cl_abap_structdescr=>component_table.
 
-    LOOP AT get_structure_components( i_context_structure ) INTO component.
+    components = get_structure_components( i_context_structure ).
+
+    LOOP AT components INTO component.
 
       CLEAR mess_fcat.
       mess_fcat-ref_table = i_context_structure.
@@ -91,13 +94,18 @@ CLASS ZCL_LOGGER_DISPLAY_PROFILE IMPLEMENTATION.
 
   METHOD zif_logger_display_profile~set_context_tree.
 
+    FIELD-SYMBOLS <lev1_fcat> type bal_T_fcat.
+    FIELD-SYMBOLS <lev2_fcat> type bal_T_fcat.
+    FIELD-SYMBOLS <lev1_sort> type bal_T_sort.
+    FIELD-SYMBOLS <lev2_sort> type bal_T_sort.
+
     CHECK display_profile IS NOT INITIAL.
 
     IF i_under_log IS INITIAL.
-      ASSIGN display_profile-lev1_fcat TO FIELD-SYMBOL(<lev1_fcat>).
-      ASSIGN display_profile-lev2_fcat TO FIELD-SYMBOL(<lev2_fcat>).
-      ASSIGN display_profile-lev1_sort TO FIELD-SYMBOL(<lev1_sort>).
-      ASSIGN display_profile-lev2_sort TO FIELD-SYMBOL(<lev2_sort>).
+      ASSIGN display_profile-lev1_fcat TO <lev1_fcat>.
+      ASSIGN display_profile-lev2_fcat TO <lev2_fcat>.
+      ASSIGN display_profile-lev1_sort TO <lev1_sort>.
+      ASSIGN display_profile-lev2_sort TO <lev2_sort>.
     ELSE.
       ASSIGN display_profile-lev2_fcat TO <lev1_fcat>.
       ASSIGN display_profile-lev3_fcat TO <lev2_fcat>.
@@ -110,13 +118,16 @@ CLASS ZCL_LOGGER_DISPLAY_PROFILE IMPLEMENTATION.
     CLEAR <lev2_sort>.
 
 
-    DATA colpos    TYPE i VALUE 100.
-    DATA sortpos   TYPE i VALUE 1.
-    DATA lev_fcat  LIKE LINE OF display_profile-lev1_fcat.
-    DATA lev_sort  LIKE LINE OF display_profile-lev2_sort.
-    DATA component TYPE cl_abap_structdescr=>component.
+    DATA colpos     TYPE i VALUE 100.
+    DATA sortpos    TYPE i VALUE 1.
+    DATA lev_fcat   LIKE LINE OF display_profile-lev1_fcat.
+    DATA lev_sort   LIKE LINE OF display_profile-lev2_sort.
+    DATA component  TYPE cl_abap_structdescr=>component.
+    DATA components TYPE cl_abap_structdescr=>component_table.
 
-    LOOP AT get_structure_components( i_context_structure ) INTO component.
+    components = get_structure_components( i_context_structure ).
+
+    LOOP AT components INTO component.
 
       CLEAR lev_fcat.
 

--- a/src/zcl_logger_display_profile.clas.abap
+++ b/src/zcl_logger_display_profile.clas.abap
@@ -71,7 +71,6 @@ CLASS ZCL_LOGGER_DISPLAY_PROFILE IMPLEMENTATION.
     CHECK display_profile IS NOT INITIAL.
 
     DATA colpos     TYPE i VALUE 100.
-    DATA sortpos    TYPE i VALUE 1.
     DATA mess_fcat  LIKE LINE OF display_profile-mess_fcat.
     DATA component  TYPE cl_abap_structdescr=>component.
     DATA components TYPE cl_abap_structdescr=>component_table.
@@ -94,10 +93,10 @@ CLASS ZCL_LOGGER_DISPLAY_PROFILE IMPLEMENTATION.
 
   METHOD zif_logger_display_profile~set_context_tree.
 
-    FIELD-SYMBOLS <lev1_fcat> type bal_T_fcat.
-    FIELD-SYMBOLS <lev2_fcat> type bal_T_fcat.
-    FIELD-SYMBOLS <lev1_sort> type bal_T_sort.
-    FIELD-SYMBOLS <lev2_sort> type bal_T_sort.
+    FIELD-SYMBOLS <lev1_fcat> TYPE bal_t_fcat.
+    FIELD-SYMBOLS <lev2_fcat> TYPE bal_t_fcat.
+    FIELD-SYMBOLS <lev1_sort> TYPE bal_t_sort.
+    FIELD-SYMBOLS <lev2_sort> TYPE bal_t_sort.
 
     CHECK display_profile IS NOT INITIAL.
 

--- a/src/zcl_logger_display_profile.clas.abap
+++ b/src/zcl_logger_display_profile.clas.abap
@@ -8,13 +8,13 @@ CLASS zcl_logger_display_profile DEFINITION
     INTERFACES zif_logger_display_profile.
   PROTECTED SECTION.
     DATA display_profile TYPE bal_s_prof.
-private section.
+  PRIVATE SECTION.
 
-  methods GET_STRUCTURE_COMPONENTS
-    importing
-      !I_STRUCTURE_NAME type CLIKE
-    returning
-      value(R_COMPONENTS) type CL_ABAP_STRUCTDESCR=>COMPONENT_TABLE .
+    METHODS get_structure_components
+      IMPORTING
+        !i_structure_name   TYPE clike
+      RETURNING
+        VALUE(r_components) TYPE cl_abap_structdescr=>component_table .
 ENDCLASS.
 
 
@@ -68,13 +68,12 @@ CLASS ZCL_LOGGER_DISPLAY_PROFILE IMPLEMENTATION.
 
     CHECK display_profile IS NOT INITIAL.
 
-    DATA colpos TYPE i VALUE 100.
-    DATA sortpos TYPE i VALUE 1.
-
+    DATA colpos    TYPE i VALUE 100.
+    DATA sortpos   TYPE i VALUE 1.
     DATA mess_fcat LIKE LINE OF display_profile-mess_fcat.
+    DATA component TYPE cl_abap_structdescr=>component.
 
-
-    LOOP AT get_structure_components( i_context_structure ) INTO data(component).
+    LOOP AT get_structure_components( i_context_structure ) INTO component.
 
       CLEAR mess_fcat.
       mess_fcat-ref_table = i_context_structure.
@@ -109,14 +108,13 @@ CLASS ZCL_LOGGER_DISPLAY_PROFILE IMPLEMENTATION.
     CLEAR <lev2_sort>.
 
 
-    DATA colpos  TYPE i VALUE 100.
-    DATA sortpos TYPE i VALUE 1.
+    DATA colpos    TYPE i VALUE 100.
+    DATA sortpos   TYPE i VALUE 1.
+    DATA lev_fcat  LIKE LINE OF display_profile-lev1_fcat.
+    DATA lev_sort  LIKE LINE OF display_profile-lev2_sort.
+    DATA component TYPE cl_abap_structdescr=>component.
 
-    DATA lev_fcat LIKE LINE OF display_profile-lev1_fcat.
-    DATA lev_sort LIKE LINE OF display_profile-lev2_sort.
-
-
-    LOOP AT get_structure_components( i_context_structure ) INTO DATA(component).
+    LOOP AT get_structure_components( i_context_structure ) INTO component.
 
       CLEAR lev_fcat.
 

--- a/src/zcl_logger_display_profile.clas.abap
+++ b/src/zcl_logger_display_profile.clas.abap
@@ -57,7 +57,8 @@ CLASS zcl_logger_display_profile IMPLEMENTATION.
 
   METHOD zif_logger_display_profile~set_value.
 
-    ASSIGN COMPONENT i_fld OF STRUCTURE display_profile TO FIELD-SYMBOL(<value>).
+    FIELD-SYMBOLS <value> TYPE any.
+    ASSIGN COMPONENT i_fld OF STRUCTURE display_profile TO <value>.
     IF sy-subrc = 0.
       <value> = i_val.
       r_self = me.
@@ -76,43 +77,59 @@ CLASS zcl_logger_display_profile IMPLEMENTATION.
     CLEAR display_profile-lev2_fcat.
     CLEAR display_profile-lev2_sort.
 
-    DATA(strucdescr) = CAST cl_abap_structdescr( cl_abap_structdescr=>describe_by_name( i_context_structure ) ).
-    DATA(colpos) = 100.
-    DATA(sortpos) = 1.
-    LOOP AT strucdescr->components INTO DATA(component).
+    DATA strucdescr TYPE REF TO cl_abap_structdescr.
+    DATA colpos TYPE i VALUE 100.
+    DATA sortpos TYPE i VALUE 1.
 
-      APPEND VALUE #(
-        ref_table = i_context_structure
-        ref_field = component-name
-        col_pos   = colpos ) TO display_profile-mess_fcat.
+    strucdescr ?= cl_abap_structdescr=>describe_by_name( i_context_structure ).
 
-      APPEND VALUE #(
-        ref_table = i_context_structure
-        ref_field = component-name
-        col_pos   = colpos ) TO display_profile-lev1_fcat.
+    DATA component TYPE abap_compdescr.
+    DATA mess_fcat LIKE LINE OF display_profile-mess_fcat.
+    DATA lev1_fcat LIKE LINE OF display_profile-lev1_fcat.
+    DATA lev2_fcat LIKE LINE OF display_profile-lev1_fcat.
+    DATA lev1_sort LIKE LINE OF display_profile-lev2_sort.
+    DATA lev2_sort LIKE LINE OF display_profile-lev2_sort.
+
+
+    LOOP AT strucdescr->components INTO component.
+
+      CLEAR mess_fcat.
+      CLEAR lev1_fcat.
+      CLEAR lev1_sort.
+
+      mess_fcat-ref_table = i_context_structure.
+      mess_fcat-ref_field = component-name.
+      mess_fcat-col_pos   = colpos.
+      APPEND mess_fcat TO display_profile-mess_fcat.
+
+      lev1_fcat-ref_table = i_context_structure.
+      lev1_fcat-ref_field = component-name.
+      lev1_fcat-col_pos   = colpos.
+      APPEND lev1_fcat TO display_profile-lev1_fcat.
+
       colpos = colpos + 1.
 
-      APPEND VALUE #(
-        ref_table = i_context_structure
-        ref_field  = component-name
-        up         = 'X'
-        spos       = sortpos ) TO display_profile-lev1_sort.
+
+      lev1_sort-ref_table = i_context_structure.
+      lev1_sort-ref_field  = component-name.
+      lev1_sort-up         = 'X'.
+      lev1_sort-spos       = sortpos.
+      APPEND lev1_sort TO display_profile-lev1_sort.
 
       sortpos = sortpos + 1.
 
     ENDLOOP.
 
-    APPEND VALUE #(
-      ref_table = 'BAL_S_SHOW'
-      ref_field = 'T_MSGTY'
-      col_pos   = colpos ) TO display_profile-lev2_fcat.
+    lev2_fcat-ref_table = 'BAL_S_SHOW'.
+    lev2_fcat-ref_field = 'T_MSGTY'.
+    lev2_fcat-col_pos   = colpos.
+    APPEND lev2_fcat TO display_profile-lev2_fcat.
 
-    APPEND VALUE #(
-      ref_table = 'BAL_S_SHOW'
-      ref_field  = 'T_MSGTY'
-      up         = 'X'
-      spos       = 1 ) TO display_profile-lev2_sort.
-
+    lev2_sort-ref_table = 'BAL_S_SHOW'.
+    lev2_sort-ref_field  = 'T_MSGTY'.
+    lev2_sort-up         = 'X'.
+    lev2_sort-spos       = 1.
+    APPEND lev2_sort TO display_profile-lev2_sort.
 
   ENDMETHOD.
 

--- a/src/zcl_logger_display_profile.clas.abap
+++ b/src/zcl_logger_display_profile.clas.abap
@@ -32,7 +32,9 @@ CLASS ZCL_LOGGER_DISPLAY_PROFILE IMPLEMENTATION.
 
 
   METHOD zif_logger_display_profile~get.
+
     r_display_profile = display_profile.
+
   ENDMETHOD.
 
 
@@ -173,5 +175,6 @@ CLASS ZCL_LOGGER_DISPLAY_PROFILE IMPLEMENTATION.
         EXPORTING
           info = |field { i_fld } does not exist| ##no_text.
     ENDIF.
+
   ENDMETHOD.
 ENDCLASS.

--- a/src/zcl_logger_display_profile.clas.abap
+++ b/src/zcl_logger_display_profile.clas.abap
@@ -1,0 +1,119 @@
+CLASS zcl_logger_display_profile DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PRIVATE
+   GLOBAL FRIENDS zcl_logger_factory.
+
+  PUBLIC SECTION.
+    INTERFACES zif_logger_display_profile.
+  PROTECTED SECTION.
+    DATA display_profile TYPE bal_s_prof.
+  PRIVATE SECTION.
+
+ENDCLASS.
+
+
+
+CLASS zcl_logger_display_profile IMPLEMENTATION.
+
+  METHOD zif_logger_display_profile~set.
+    CASE abap_true.
+      WHEN i_detlevel.
+        CALL FUNCTION 'BAL_DSP_PROFILE_DETLEVEL_GET'
+          IMPORTING
+            e_s_display_profile = display_profile.
+      WHEN i_no_tree.
+        CALL FUNCTION 'BAL_DSP_PROFILE_NO_TREE_GET'
+          IMPORTING
+            e_s_display_profile = display_profile.
+      WHEN i_popup.
+        CALL FUNCTION 'BAL_DSP_PROFILE_POPUP_GET'
+          IMPORTING
+            e_s_display_profile = display_profile.
+      WHEN i_single_log.
+        CALL FUNCTION 'BAL_DSP_PROFILE_SINGLE_LOG_GET'
+          IMPORTING
+            e_s_display_profile = display_profile.
+      WHEN OTHERS.
+        CALL FUNCTION 'BAL_DSP_PROFILE_STANDARD_GET'
+          IMPORTING
+            e_s_display_profile = display_profile.
+    ENDCASE.
+
+    r_self = me.
+  ENDMETHOD.
+
+  METHOD zif_logger_display_profile~set_grid.
+    zif_logger_display_profile~set_value(
+      i_fld = 'USE_GRID'
+      i_val = i_grid_mode ).
+
+    r_self = me.
+  ENDMETHOD.
+
+  METHOD zif_logger_display_profile~get.
+    r_display_profile = display_profile.
+  ENDMETHOD.
+
+  METHOD zif_logger_display_profile~set_value.
+
+    ASSIGN COMPONENT i_fld OF STRUCTURE display_profile TO FIELD-SYMBOL(<value>).
+    IF sy-subrc = 0.
+      <value> = i_val.
+      r_self = me.
+    ELSE.
+      RAISE EXCEPTION TYPE zcx_logger_display_profile
+        EXPORTING
+          info = |field { i_fld } does not exist| ##no_text.
+    ENDIF.
+  ENDMETHOD.
+
+  METHOD zif_logger_display_profile~set_context.
+    CHECK display_profile IS NOT INITIAL.
+
+    CLEAR display_profile-lev1_fcat.
+    CLEAR display_profile-lev1_sort.
+    CLEAR display_profile-lev2_fcat.
+    CLEAR display_profile-lev2_sort.
+
+    DATA(strucdescr) = CAST cl_abap_structdescr( cl_abap_structdescr=>describe_by_name( i_context_structure ) ).
+    DATA(colpos) = 100.
+    DATA(sortpos) = 1.
+    LOOP AT strucdescr->components INTO DATA(component).
+
+      APPEND VALUE #(
+        ref_table = i_context_structure
+        ref_field = component-name
+        col_pos   = colpos ) TO display_profile-mess_fcat.
+
+      APPEND VALUE #(
+        ref_table = i_context_structure
+        ref_field = component-name
+        col_pos   = colpos ) TO display_profile-lev1_fcat.
+      colpos = colpos + 1.
+
+      APPEND VALUE #(
+        ref_table = i_context_structure
+        ref_field  = component-name
+        up         = 'X'
+        spos       = sortpos ) TO display_profile-lev1_sort.
+
+      sortpos = sortpos + 1.
+
+    ENDLOOP.
+
+    APPEND VALUE #(
+      ref_table = 'BAL_S_SHOW'
+      ref_field = 'T_MSGTY'
+      col_pos   = colpos ) TO display_profile-lev2_fcat.
+
+    APPEND VALUE #(
+      ref_table = 'BAL_S_SHOW'
+      ref_field  = 'T_MSGTY'
+      up         = 'X'
+      spos       = 1 ) TO display_profile-lev2_sort.
+
+
+  ENDMETHOD.
+
+ENDCLASS.

--- a/src/zcl_logger_display_profile.clas.xml
+++ b/src/zcl_logger_display_profile.clas.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCL_LOGGER_DISPLAY_PROFILE</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>ABAP Logger: Display profile</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/zcl_logger_display_profile.clas.xml
+++ b/src/zcl_logger_display_profile.clas.xml
@@ -11,6 +11,14 @@
     <FIXPT>X</FIXPT>
     <UNICODE>X</UNICODE>
    </VSEOCLASS>
+   <DESCRIPTIONS_SUB>
+    <SEOSUBCOTX>
+     <CMPNAME>GET_STRUCTURE_COMPONENTS</CMPNAME>
+     <SCONAME>R_COMPONENTS</SCONAME>
+     <LANGU>E</LANGU>
+     <DESCRIPT>Komponentenbeschreibungstabelle</DESCRIPT>
+    </SEOSUBCOTX>
+   </DESCRIPTIONS_SUB>
   </asx:values>
  </asx:abap>
 </abapGit>

--- a/src/zcl_logger_factory.clas.abap
+++ b/src/zcl_logger_factory.clas.abap
@@ -36,6 +36,16 @@ CLASS zcl_logger_factory DEFINITION
     CLASS-METHODS create_collection
       RETURNING
         VALUE(r_collection) TYPE REF TO zif_logger_collection .
+
+    CLASS-METHODS create_display_profile
+      IMPORTING
+        i_detlevel               TYPE clike OPTIONAL
+        i_no_tree                TYPE clike OPTIONAL
+        i_popup                  TYPE clike OPTIONAL
+        i_single_log             TYPE clike OPTIONAL
+        i_standard               TYPE clike DEFAULT abap_true
+      RETURNING
+        VALUE(r_display_profile) TYPE REF TO zif_logger_display_profile.
   PROTECTED SECTION.
   PRIVATE SECTION.
 ENDCLASS.
@@ -183,6 +193,16 @@ CLASS zcl_logger_factory IMPLEMENTATION.
 
   METHOD create_collection.
     CREATE OBJECT r_collection TYPE zcl_logger_collection.
+  ENDMETHOD.
+
+  METHOD create_display_profile.
+    r_display_profile = NEW zcl_logger_display_profile( ).
+    r_display_profile->set(
+     i_detlevel    = i_detlevel
+     i_no_tree     = i_no_tree
+     i_popup       = i_popup
+     i_single_log  = i_single_log
+     i_standard    = i_standard ).
   ENDMETHOD.
 
 ENDCLASS.

--- a/src/zcl_logger_factory.clas.abap
+++ b/src/zcl_logger_factory.clas.abap
@@ -196,7 +196,7 @@ CLASS zcl_logger_factory IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD create_display_profile.
-    r_display_profile = NEW zcl_logger_display_profile( ).
+    CREATE OBJECT r_display_profile TYPE zcl_logger_display_profile.
     r_display_profile->set(
      i_detlevel    = i_detlevel
      i_no_tree     = i_no_tree

--- a/src/zcx_logger.clas.abap
+++ b/src/zcx_logger.clas.abap
@@ -1,11 +1,12 @@
-class ZCX_LOGGER_DISPLAY_PROFILE definition
+class ZCX_LOGGER definition
   public
-  inheriting from ZCX_LOGGER
+  inheriting from CX_NO_CHECK
   create public .
 
 public section.
 
-  constants ZCX_LOGGER_DISPLAY_PROFILE type SOTR_CONC value 'B9D98DB24EAF1EDD8ED3241224D60A6A' ##NO_TEXT.
+  constants ZCX_LOGGER type SOTR_CONC value 'B9D98DB24EAF1EDD8ED3241224D60A6A' ##NO_TEXT.
+  data INFO type STRING .
 
   methods CONSTRUCTOR
     importing
@@ -18,7 +19,7 @@ ENDCLASS.
 
 
 
-CLASS ZCX_LOGGER_DISPLAY_PROFILE IMPLEMENTATION.
+CLASS ZCX_LOGGER IMPLEMENTATION.
 
 
   method CONSTRUCTOR.
@@ -26,10 +27,10 @@ CALL METHOD SUPER->CONSTRUCTOR
 EXPORTING
 TEXTID = TEXTID
 PREVIOUS = PREVIOUS
-INFO = INFO
 .
  IF textid IS INITIAL.
-   me->textid = ZCX_LOGGER_DISPLAY_PROFILE .
+   me->textid = ZCX_LOGGER .
  ENDIF.
+me->INFO = INFO .
   endmethod.
 ENDCLASS.

--- a/src/zcx_logger.clas.xml
+++ b/src/zcx_logger.clas.xml
@@ -3,9 +3,9 @@
  <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
   <asx:values>
    <VSEOCLASS>
-    <CLSNAME>ZCX_LOGGER_DISPLAY_PROFILE</CLSNAME>
+    <CLSNAME>ZCX_LOGGER</CLSNAME>
     <LANGU>E</LANGU>
-    <DESCRIPT>ABAP Logger: display profile exceptions</DESCRIPT>
+    <DESCRIPT>ABAP Logger: general exceptions</DESCRIPT>
     <CATEGORY>40</CATEGORY>
     <STATE>1</STATE>
     <CLSCCINCL>X</CLSCCINCL>
@@ -37,7 +37,7 @@
     <SOTR_USE>
      <PGMID>LIMU</PGMID>
      <OBJECT>CPUB</OBJECT>
-     <OBJ_NAME>ZCX_LOGGER_DISPLAY_PROFILE</OBJ_NAME>
+     <OBJ_NAME>ZCX_LOGGER</OBJ_NAME>
      <CONCEPT>B9D98DB24EAF1EDD8ED3241224D60A6A</CONCEPT>
      <LFD_NUM>0001</LFD_NUM>
     </SOTR_USE>

--- a/src/zcx_logger_display_profile.clas.abap
+++ b/src/zcx_logger_display_profile.clas.abap
@@ -1,0 +1,36 @@
+class ZCX_LOGGER_DISPLAY_PROFILE definition
+  public
+  inheriting from CX_NO_CHECK
+  create public .
+
+public section.
+
+  constants ZCX_LOGGER_DISPLAY_PROFILE type SOTR_CONC value 'B9D98DB24EAF1EDD8ED3241224D60A6A' ##NO_TEXT.
+  data INFO type STRING .
+
+  methods CONSTRUCTOR
+    importing
+      !TEXTID like TEXTID optional
+      !PREVIOUS like PREVIOUS optional
+      !INFO type STRING optional .
+protected section.
+private section.
+ENDCLASS.
+
+
+
+CLASS ZCX_LOGGER_DISPLAY_PROFILE IMPLEMENTATION.
+
+
+  method CONSTRUCTOR.
+CALL METHOD SUPER->CONSTRUCTOR
+EXPORTING
+TEXTID = TEXTID
+PREVIOUS = PREVIOUS
+.
+ IF textid IS INITIAL.
+   me->textid = ZCX_LOGGER_DISPLAY_PROFILE .
+ ENDIF.
+me->INFO = INFO .
+  endmethod.
+ENDCLASS.

--- a/src/zcx_logger_display_profile.clas.xml
+++ b/src/zcx_logger_display_profile.clas.xml
@@ -1,0 +1,54 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCX_LOGGER_DISPLAY_PROFILE</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>ABAP Logger: general exceptions</DESCRIPT>
+    <CATEGORY>40</CATEGORY>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+   <SOTR>
+    <item>
+     <HEADER>
+      <CONCEPT>B9D98DB24EAF1EDD8ED3241224D60A6A</CONCEPT>
+      <CREA_LAN>E</CREA_LAN>
+      <TRALA_TYPE>1</TRALA_TYPE>
+      <OBJID_VEC>CA==</OBJID_VEC>
+     </HEADER>
+     <ENTRIES>
+      <SOTR_TEXT>
+       <CONCEPT>B9D98DB24EAF1EDD8ED3241224D60A6A</CONCEPT>
+       <LANGU>E</LANGU>
+       <LFD_NUM>0001</LFD_NUM>
+       <FLAG_CNTXT>X</FLAG_CNTXT>
+       <STATUS>R</STATUS>
+       <LENGTH>255</LENGTH>
+       <TEXT>Error in display profile: &amp;info&amp;</TEXT>
+      </SOTR_TEXT>
+     </ENTRIES>
+    </item>
+   </SOTR>
+   <SOTR_USE>
+    <SOTR_USE>
+     <PGMID>LIMU</PGMID>
+     <OBJECT>CPUB</OBJECT>
+     <OBJ_NAME>ZCX_LOGGER_DISPLAY_PROFILE</OBJ_NAME>
+     <CONCEPT>B9D98DB24EAF1EDD8ED3241224D60A6A</CONCEPT>
+     <LFD_NUM>0001</LFD_NUM>
+    </SOTR_USE>
+   </SOTR_USE>
+   <DESCRIPTIONS>
+    <SEOCOMPOTX>
+     <CMPNAME>CONSTRUCTOR</CMPNAME>
+     <LANGU>E</LANGU>
+     <DESCRIPT>CONSTRUCTOR</DESCRIPT>
+    </SEOCOMPOTX>
+   </DESCRIPTIONS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/zif_logger_display_profile.intf.abap
+++ b/src/zif_logger_display_profile.intf.abap
@@ -1,35 +1,35 @@
-interface ZIF_LOGGER_DISPLAY_PROFILE
-  public .
+INTERFACE zif_logger_display_profile
+  PUBLIC .
 
 
-  methods SET
-    importing
-      !I_DETLEVEL type CLIKE optional
-      !I_NO_TREE type CLIKE optional
-      !I_POPUP type CLIKE optional
-      !I_SINGLE_LOG type CLIKE optional
-      !I_STANDARD type CLIKE default ABAP_TRUE
-    returning
-      value(R_SELF) type ref to ZIF_LOGGER_DISPLAY_PROFILE .
-  methods GET
-    returning
-      value(R_DISPLAY_PROFILE) type BAL_S_PROF .
-  methods SET_GRID
-    importing
-      !I_GRID_MODE type CLIKE
-    returning
-      value(R_SELF) type ref to ZIF_LOGGER_DISPLAY_PROFILE .
-  methods SET_VALUE
-    importing
-      !I_FLD type CLIKE
-      !I_VAL type ANY
-    returning
-      value(R_SELF) type ref to ZIF_LOGGER_DISPLAY_PROFILE .
-  methods SET_CONTEXT_TREE
-    importing
-      !I_CONTEXT_STRUCTURE type CLIKE
-      !I_UNDER_LOG type CLIKE default SPACE .
-  methods SET_CONTEXT_MESSAGE
-    importing
-      !I_CONTEXT_STRUCTURE type CLIKE .
-endinterface.
+  METHODS set
+    IMPORTING
+      !i_detlevel   TYPE clike OPTIONAL
+      !i_no_tree    TYPE clike OPTIONAL
+      !i_popup      TYPE clike OPTIONAL
+      !i_single_log TYPE clike OPTIONAL
+      !i_standard   TYPE clike DEFAULT abap_true
+    RETURNING
+      VALUE(r_self) TYPE REF TO zif_logger_display_profile .
+  METHODS get
+    RETURNING
+      VALUE(r_display_profile) TYPE bal_s_prof .
+  METHODS set_grid
+    IMPORTING
+      !i_grid_mode  TYPE clike
+    RETURNING
+      VALUE(r_self) TYPE REF TO zif_logger_display_profile .
+  METHODS set_value
+    IMPORTING
+      !i_fld        TYPE clike
+      !i_val        TYPE any
+    RETURNING
+      VALUE(r_self) TYPE REF TO zif_logger_display_profile .
+  METHODS set_context_tree
+    IMPORTING
+      !i_context_structure TYPE clike
+      !i_under_log         TYPE clike DEFAULT space .
+  METHODS set_context_message
+    IMPORTING
+      !i_context_structure TYPE clike .
+ENDINTERFACE.

--- a/src/zif_logger_display_profile.intf.abap
+++ b/src/zif_logger_display_profile.intf.abap
@@ -1,29 +1,35 @@
-INTERFACE zif_logger_display_profile
-  PUBLIC .
-  METHODS set
-    IMPORTING
-      i_detlevel    TYPE clike OPTIONAL
-      i_no_tree     TYPE clike OPTIONAL
-      i_popup       TYPE clike OPTIONAL
-      i_single_log  TYPE clike OPTIONAL
-      i_standard    TYPE clike DEFAULT abap_true
-    RETURNING
-      VALUE(r_self) TYPE REF TO zif_logger_display_profile.
-  METHODS get
-    RETURNING VALUE(r_display_profile) TYPE bal_s_prof.
-  METHODS set_grid
-    IMPORTING
-      i_grid_mode   TYPE clike
-    RETURNING
-      VALUE(r_self) TYPE REF TO zif_logger_display_profile.
-  METHODS set_value
-    IMPORTING
-      i_fld       TYPE clike
-      i_val       TYPE any
-    RETURNING
-      VALUE(r_self) TYPE REF TO zif_logger_display_profile.
-  METHODS set_context
-    IMPORTING
-      i_context_structure TYPE clike.
+interface ZIF_LOGGER_DISPLAY_PROFILE
+  public .
 
-ENDINTERFACE.
+
+  methods SET
+    importing
+      !I_DETLEVEL type CLIKE optional
+      !I_NO_TREE type CLIKE optional
+      !I_POPUP type CLIKE optional
+      !I_SINGLE_LOG type CLIKE optional
+      !I_STANDARD type CLIKE default ABAP_TRUE
+    returning
+      value(R_SELF) type ref to ZIF_LOGGER_DISPLAY_PROFILE .
+  methods GET
+    returning
+      value(R_DISPLAY_PROFILE) type BAL_S_PROF .
+  methods SET_GRID
+    importing
+      !I_GRID_MODE type CLIKE
+    returning
+      value(R_SELF) type ref to ZIF_LOGGER_DISPLAY_PROFILE .
+  methods SET_VALUE
+    importing
+      !I_FLD type CLIKE
+      !I_VAL type ANY
+    returning
+      value(R_SELF) type ref to ZIF_LOGGER_DISPLAY_PROFILE .
+  methods SET_CONTEXT_TREE
+    importing
+      !I_CONTEXT_STRUCTURE type CLIKE
+      !I_UNDER_LOG type CLIKE default SPACE .
+  methods SET_CONTEXT_MESSAGE
+    importing
+      !I_CONTEXT_STRUCTURE type CLIKE .
+endinterface.

--- a/src/zif_logger_display_profile.intf.abap
+++ b/src/zif_logger_display_profile.intf.abap
@@ -1,0 +1,29 @@
+INTERFACE zif_logger_display_profile
+  PUBLIC .
+  METHODS set
+    IMPORTING
+      i_detlevel    TYPE clike OPTIONAL
+      i_no_tree     TYPE clike OPTIONAL
+      i_popup       TYPE clike OPTIONAL
+      i_single_log  TYPE clike OPTIONAL
+      i_standard    TYPE clike DEFAULT abap_true
+    RETURNING
+      VALUE(r_self) TYPE REF TO zif_logger_display_profile.
+  METHODS get
+    RETURNING VALUE(r_display_profile) TYPE bal_s_prof.
+  METHODS set_grid
+    IMPORTING
+      i_grid_mode   TYPE clike
+    RETURNING
+      VALUE(r_self) TYPE REF TO zif_logger_display_profile.
+  METHODS set_value
+    IMPORTING
+      i_fld       TYPE clike
+      i_val       TYPE any
+    RETURNING
+      VALUE(r_self) TYPE REF TO zif_logger_display_profile.
+  METHODS set_context
+    IMPORTING
+      i_context_structure TYPE clike.
+
+ENDINTERFACE.

--- a/src/zif_logger_display_profile.intf.xml
+++ b/src/zif_logger_display_profile.intf.xml
@@ -10,6 +10,14 @@
     <STATE>1</STATE>
     <UNICODE>X</UNICODE>
    </VSEOINTERF>
+   <DESCRIPTIONS_SUB>
+    <SEOSUBCOTX>
+     <CMPNAME>SET_CONTEXT_TREE</CMPNAME>
+     <SCONAME>I_UNDER_LOG</SCONAME>
+     <LANGU>E</LANGU>
+     <DESCRIPT>X: Display context fields under each log</DESCRIPT>
+    </SEOSUBCOTX>
+   </DESCRIPTIONS_SUB>
   </asx:values>
  </asx:abap>
 </abapGit>

--- a/src/zif_logger_display_profile.intf.xml
+++ b/src/zif_logger_display_profile.intf.xml
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_INTF" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOINTERF>
+    <CLSNAME>ZIF_LOGGER_DISPLAY_PROFILE</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>ABAP Logger: Display profile</DESCRIPT>
+    <EXPOSURE>2</EXPOSURE>
+    <STATE>1</STATE>
+    <UNICODE>X</UNICODE>
+   </VSEOINTERF>
+  </asx:values>
+ </asx:abap>
+</abapGit>


### PR DESCRIPTION
I added a class to get the display profile.
Although it's only a function call, it annoys me that it's not object oriented.
plus: there are so many functionalities which are not obvious so I would like to add methods for it.
To use the context feature I added the method SET_CONTEXT where the fields of the structure used for the context will be added to the field catalog.

I also added the method SET_VALUE to set values of the display profile. I am not sure if this is a good way... I like it if attributes are public so that they can be easily changed from outside. But I know that i am lonely with this opinion... 😄 

Demo display profile
```
"Create logger
DATA(my_logger) = zcl_logger_factory=>create_log( desc = 'ABAP Logger Demo 03' ) ##no_text.

"create display profile
DATA(my_profile) = zcl_logger_factory=>create_display_profile( )->set_grid( abap_true ).
TRY.
    my_profile->set_value( i_fld = 'SHOW_ALL' i_val = abap_true ).
    my_profile->set_value( i_fld = 'NONSENSE' i_val = 'Does not matter' ) ##no_text.
  CATCH zcx_logger_display_profile INTO DATA(error).
    my_logger->e( error->get_text( ) ).
ENDTRY.


"put some messages
my_logger->i( 'program start' ) ##no_text.
my_logger->w( 'This is a warning' ) ##no_text.
my_logger->s( 'Everything ok at the end' ) ##no_text.
my_logger->s( 'Log saved. See transaction SLG1' ) ##no_text.

"Display messages in popup
my_logger->popup( my_profile->get( ) ).

```
Demo set context

```
"create display profile
DATA(my_profile) = zcl_logger_factory=>create_display_profile(
               i_single_log  = abap_true )->set_grid( abap_true ).
my_profile->set_context( 'ZLOGGER_DEMO_03_CONTEXT_S' ).
my_profile->set_value(
    i_fld = 'EXP_LEVEL'
    i_val = 0 ).
```