### PR TITLE
fix: adding syst messages for methods i,a,e,w,s

### DIFF
--- a/src/zcl_logger.clas.abap
+++ b/src/zcl_logger.clas.abap
@@ -383,7 +383,6 @@ CLASS zcl_logger IMPLEMENTATION.
 
     " Remember system message since it might get changed inadvertently
     syst_buffer = syst.
-    
     IF context IS NOT INITIAL.
       ASSIGN context TO <context_val>.
       formatted_context-value = <context_val>.

--- a/src/zcl_logger.clas.abap
+++ b/src/zcl_logger.clas.abap
@@ -372,6 +372,7 @@ CLASS zcl_logger IMPLEMENTATION.
           "these objects could be moved into their own method
           "see adt://***/sap/bc/adt/oo/classes/zcl_logger/source/main#start=391,10;end=415,61
           symsg                    TYPE symsg,
+          syst_buffer              TYPE syst,
           loggable                 TYPE REF TO zif_loggable_object,
           loggable_object_messages TYPE zif_loggable_object=>tty_messages.
 
@@ -380,6 +381,9 @@ CLASS zcl_logger IMPLEMENTATION.
                    <context_val>             TYPE any,
                    <loggable_object_message> TYPE zif_loggable_object=>ty_message.
 
+    " Remember system message since it might get changed inadvertently
+    syst_buffer = syst.
+    
     IF context IS NOT INITIAL.
       ASSIGN context TO <context_val>.
       formatted_context-value = <context_val>.
@@ -412,8 +416,8 @@ CLASS zcl_logger IMPLEMENTATION.
     msg_type    = cl_abap_typedescr=>describe_by_data( obj_to_log ).
     struct_kind = get_struct_kind( msg_type ).
 
-    IF obj_to_log IS NOT SUPPLIED.
-      detailed_msg = add_syst_msg( syst ).
+    IF obj_to_log IS INITIAL.
+      detailed_msg = add_syst_msg( syst_buffer ).
     ELSEIF struct_kind = c_struct_kind-syst.
       detailed_msg = add_syst_msg( obj_to_log ).
     ELSEIF struct_kind = c_struct_kind-bapi.


### PR DESCRIPTION
Closes https://github.com/ABAP-Logger/ABAP-Logger/issues/120

Fixes logging of system message when using the i,a,e,w,s-methods and passing no parameters