### PR TITLE
refactor: Clean ABAP changes

### DIFF
--- a/abaplint.json
+++ b/abaplint.json
@@ -21,12 +21,29 @@
   },
   "rules": {
     "begin_end_names": true,
+    "check_comments": {
+        "allowEndOfLine": true
+    },
     "check_ddic": true,
     "check_include": true,
     "check_syntax": true,
+    "functional_writing": {
+        "ignoreExceptions": true
+    },
+    "exporting": true,
     "global_class": true,
     "implement_methods": true,
+    "indentation": {
+        "alignTryCatch": false,
+        "ignoreExceptions": false,
+        "globalClassSkipFirst": false,
+        "ignoreGlobalClassDefinition": false,
+        "ignoreGlobalInterface": false,
+        "selectionScreenBlockIndentation": false
+    },
+    "in_statement_indentation": true,
     "keyword_case": true,
+    "omit_receiving": true,
     "method_implemented_twice": true,
     "parser_error": true,
     "parser_missing_space": true,

--- a/src/zcl_logger.clas.abap
+++ b/src/zcl_logger.clas.abap
@@ -85,7 +85,7 @@ CLASS zcl_logger DEFINITION
         IMPORTING
           msgtype                   TYPE symsgty OPTIONAL
         RETURNING
-          VALUE(rt_message_handles) TYPE bal_t_msgh ,
+          VALUE(rt_message_handles) TYPE bal_t_msgh,
 
       add_structure
         IMPORTING
@@ -201,7 +201,8 @@ CLASS zcl_logger IMPLEMENTATION.
     ENDWHILE.
 
     FIELD-SYMBOLS <ret> LIKE LINE OF rt_exception_data_table.
-     "Display the deepest exception first
+
+    "Display the deepest exception first
     SORT exceptions BY level DESCENDING.
     LOOP AT exceptions ASSIGNING <ex>.
       APPEND INITIAL LINE TO rt_exception_data_table ASSIGNING <ret>.

--- a/src/zcl_logger.clas.abap
+++ b/src/zcl_logger.clas.abap
@@ -1,8 +1,3 @@
-*----------------------------------------------------------------------*
-*       CLASS ZCL_LOGGER DEFINITION
-*----------------------------------------------------------------------*
-*
-*----------------------------------------------------------------------*
 CLASS zcl_logger DEFINITION
   PUBLIC
   CREATE PRIVATE
@@ -11,7 +6,7 @@ CLASS zcl_logger DEFINITION
   PUBLIC SECTION.
 *"* public components of class ZCL_LOGGER
 *"* do not include other source files here!!!
-    TYPE-POOLS abap .
+    TYPE-POOLS abap.
 
     INTERFACES zif_logger.
     ALIASES: add FOR zif_logger~add,
@@ -43,7 +38,7 @@ CLASS zcl_logger DEFINITION
         !auto_save      TYPE abap_bool OPTIONAL
         !second_db_conn TYPE abap_bool DEFAULT abap_true
       RETURNING
-        VALUE(r_log)    TYPE REF TO zcl_logger .
+        VALUE(r_log)    TYPE REF TO zcl_logger.
 
     "! Reopens an already existing log.
     "! For backwards compatibility only! Use ZCL_LOGGER_FACTORY instead.
@@ -55,7 +50,7 @@ CLASS zcl_logger DEFINITION
         !create_if_does_not_exist TYPE abap_bool DEFAULT abap_false
         !auto_save                TYPE abap_bool OPTIONAL
       RETURNING
-        VALUE(r_log)              TYPE REF TO zcl_logger .
+        VALUE(r_log)              TYPE REF TO zcl_logger.
 
   PROTECTED SECTION.
 *"* protected components of class ZCL_LOGGER
@@ -68,12 +63,12 @@ CLASS zcl_logger DEFINITION
         bapi  TYPE i VALUE 2,
         bdc   TYPE i VALUE 3,
         sprot TYPE i VALUE 4,
-      END OF c_struct_kind .
+      END OF c_struct_kind.
 
 *"* private components of class ZCL_LOGGER
 *"* do not include other source files here!!!
-    DATA sec_connection     TYPE abap_bool .
-    DATA sec_connect_commit TYPE abap_bool .
+    DATA sec_connection     TYPE abap_bool.
+    DATA sec_connect_commit TYPE abap_bool.
     DATA settings           TYPE REF TO zif_logger_settings.
 
     METHODS:
@@ -103,40 +98,39 @@ CLASS zcl_logger DEFINITION
           importance    TYPE balprobcl OPTIONAL
             PREFERRED PARAMETER obj_to_log
         RETURNING
-          VALUE(self)   TYPE REF TO zif_logger .
+          VALUE(self)   TYPE REF TO zif_logger.
 
     METHODS save_log.
     METHODS get_struct_kind
       IMPORTING
         !msg_type     TYPE REF TO cl_abap_typedescr
       RETURNING
-        VALUE(result) TYPE string .
+        VALUE(result) TYPE string.
     METHODS add_syst_msg
       IMPORTING
         !obj_to_log         TYPE any
       RETURNING
-        VALUE(detailed_msg) TYPE bal_s_msg .
+        VALUE(detailed_msg) TYPE bal_s_msg.
     METHODS add_bapi_msg
       IMPORTING
         !obj_to_log         TYPE any
       RETURNING
-        VALUE(detailed_msg) TYPE bal_s_msg .
+        VALUE(detailed_msg) TYPE bal_s_msg.
     METHODS add_bdc_msg
       IMPORTING
         !obj_to_log         TYPE any
       RETURNING
-        VALUE(detailed_msg) TYPE bal_s_msg .
+        VALUE(detailed_msg) TYPE bal_s_msg.
     METHODS add_sprot_msg
       IMPORTING
         !obj_to_log         TYPE any
       RETURNING
-        VALUE(detailed_msg) TYPE bal_s_msg .
+        VALUE(detailed_msg) TYPE bal_s_msg.
 ENDCLASS.
 
 
 
 CLASS zcl_logger IMPLEMENTATION.
-
 
   METHOD add_bapi_msg.
     DATA bapi_message TYPE bapiret1.
@@ -150,32 +144,29 @@ CLASS zcl_logger IMPLEMENTATION.
     detailed_msg-msgv4 = bapi_message-message_v4.
   ENDMETHOD.
 
-
   METHOD add_bdc_msg.
     DATA bdc_message TYPE bdcmsgcoll.
     MOVE-CORRESPONDING obj_to_log TO bdc_message.
-    detailed_msg-msgty = bdc_message-msgtyp.               "!
+    detailed_msg-msgty = bdc_message-msgtyp.
     detailed_msg-msgid = bdc_message-msgid.
-    detailed_msg-msgno = bdc_message-msgnr.                "!
+    detailed_msg-msgno = bdc_message-msgnr.
     detailed_msg-msgv1 = bdc_message-msgv1.
     detailed_msg-msgv2 = bdc_message-msgv2.
     detailed_msg-msgv3 = bdc_message-msgv3.
     detailed_msg-msgv4 = bdc_message-msgv4.
   ENDMETHOD.
 
-
   METHOD add_sprot_msg.
     DATA sprot_message TYPE sprot_u.
     MOVE-CORRESPONDING obj_to_log TO sprot_message.
     detailed_msg-msgty = sprot_message-severity.
     detailed_msg-msgid = sprot_message-ag.
-    detailed_msg-msgno = sprot_message-msgnr.              "!
+    detailed_msg-msgno = sprot_message-msgnr.
     detailed_msg-msgv1 = sprot_message-var1.
     detailed_msg-msgv2 = sprot_message-var2.
     detailed_msg-msgv3 = sprot_message-var3.
     detailed_msg-msgv4 = sprot_message-var4.
   ENDMETHOD.
-
 
   METHOD add_syst_msg.
     DATA syst_message TYPE symsg.
@@ -210,7 +201,8 @@ CLASS zcl_logger IMPLEMENTATION.
     ENDWHILE.
 
     FIELD-SYMBOLS <ret> LIKE LINE OF rt_exception_data_table.
-    SORT exceptions BY level DESCENDING.                   "Display the deepest exception first
+     "Display the deepest exception first
+    SORT exceptions BY level DESCENDING.
     LOOP AT exceptions ASSIGNING <ex>.
       APPEND INITIAL LINE TO rt_exception_data_table ASSIGNING <ret>.
       <ret>-exception = <ex>-exception.
@@ -219,9 +211,7 @@ CLASS zcl_logger IMPLEMENTATION.
     ENDLOOP.
   ENDMETHOD.
 
-
   METHOD get_message_handles.
-
     DATA: log_handle TYPE bal_t_logh,
           filter     TYPE bal_s_mfil.
 
@@ -244,12 +234,9 @@ CLASS zcl_logger IMPLEMENTATION.
         e_t_msg_handle = rt_message_handles
       EXCEPTIONS
         msg_not_found  = 0.
-
   ENDMETHOD.
 
-
   METHOD get_struct_kind.
-
     DATA: msg_struct_kind TYPE REF TO cl_abap_structdescr,
           components      TYPE abap_compdescr_tab,
           component       LIKE LINE OF components,
@@ -259,7 +246,7 @@ CLASS zcl_logger IMPLEMENTATION.
           sprot_count     TYPE i.
 
     IF msg_type->type_kind = cl_abap_typedescr=>typekind_struct1
-      OR msg_type->type_kind = cl_abap_typedescr=>typekind_struct2.
+        OR msg_type->type_kind = cl_abap_typedescr=>typekind_struct2.
 
       msg_struct_kind ?= msg_type.
       components = msg_struct_kind->components.
@@ -291,12 +278,9 @@ CLASS zcl_logger IMPLEMENTATION.
         result = c_struct_kind-sprot.
       ENDIF.
     ENDIF.
-
   ENDMETHOD.
 
-
   METHOD new.
-
     IF auto_save IS SUPPLIED.
       r_log ?= zcl_logger_factory=>create_log(
         object = object
@@ -305,8 +289,7 @@ CLASS zcl_logger IMPLEMENTATION.
         context = context
         settings = zcl_logger_factory=>create_settings(
           )->set_usage_of_secondary_db_conn( second_db_conn
-          )->set_autosave( auto_save )
-      ).
+          )->set_autosave( auto_save ) ).
     ELSE.
       r_log ?= zcl_logger_factory=>create_log(
         object = object
@@ -314,15 +297,11 @@ CLASS zcl_logger IMPLEMENTATION.
         desc = desc
         context = context
         settings = zcl_logger_factory=>create_settings(
-          )->set_usage_of_secondary_db_conn( second_db_conn )
-      ).
+          )->set_usage_of_secondary_db_conn( second_db_conn ) ).
     ENDIF.
-
   ENDMETHOD.
 
-
   METHOD open.
-
     IF auto_save IS SUPPLIED.
       r_log ?= zcl_logger_factory=>open_log(
         object = object
@@ -330,19 +309,15 @@ CLASS zcl_logger IMPLEMENTATION.
         desc = desc
         create_if_does_not_exist = create_if_does_not_exist
         settings = zcl_logger_factory=>create_settings(
-          )->set_autosave( auto_save )
-      ).
+          )->set_autosave( auto_save ) ).
     ELSE.
       r_log ?= zcl_logger_factory=>open_log(
         object = object
         subobject = subobject
         desc = desc
-        create_if_does_not_exist = create_if_does_not_exist
-      ).
+        create_if_does_not_exist = create_if_does_not_exist ).
     ENDIF.
-
   ENDMETHOD.
-
 
   METHOD zif_logger~a.
     self = add(
@@ -356,9 +331,7 @@ CLASS zcl_logger IMPLEMENTATION.
       importance          = importance ).
   ENDMETHOD.
 
-
   METHOD zif_logger~add.
-
     DATA: detailed_msg             TYPE bal_s_msg,
           exception_data_table     TYPE tty_exception_data,
           free_text_msg            TYPE char200,
@@ -429,7 +402,7 @@ CLASS zcl_logger IMPLEMENTATION.
       TRY.
           "BEGIN this could/should be moved into its own method
           loggable ?= obj_to_log.
-          loggable_object_messages = loggable->get_message_table( ) .
+          loggable_object_messages = loggable->get_message_table( ).
           LOOP AT loggable_object_messages ASSIGNING <loggable_object_message>.
             IF <loggable_object_message>-symsg IS NOT INITIAL.
               MOVE-CORRESPONDING <loggable_object_message>-symsg TO symsg.
@@ -459,7 +432,7 @@ CLASS zcl_logger IMPLEMENTATION.
           ELSE.
             message_type = type.
           ENDIF.
-          exception_data_table = me->drill_down_into_exception(
+          exception_data_table = drill_down_into_exception(
               exception   = obj_to_log
               type        = message_type
               importance  = importance
@@ -572,7 +545,6 @@ CLASS zcl_logger IMPLEMENTATION.
     add( '--- End of structure ---' ).
   ENDMETHOD.
 
-
   METHOD zif_logger~e.
     self                  = add(
       obj_to_log          = obj_to_log
@@ -584,7 +556,6 @@ CLASS zcl_logger IMPLEMENTATION.
       type                = 'E'
       importance          = importance ).
   ENDMETHOD.
-
 
   METHOD zif_logger~export_to_table.
     DATA: message_handles TYPE bal_t_msgh,
@@ -623,12 +594,9 @@ CLASS zcl_logger IMPLEMENTATION.
         APPEND bapiret2 TO rt_bapiret.
       ENDIF.
     ENDLOOP.
-
   ENDMETHOD.
 
-
   METHOD zif_logger~fullscreen.
-
     DATA:
       profile        TYPE bal_s_prof,
       lt_log_handles TYPE bal_t_logh.
@@ -643,23 +611,15 @@ CLASS zcl_logger IMPLEMENTATION.
       EXPORTING
         i_s_display_profile = profile
         i_t_log_handle      = lt_log_handles.
-
   ENDMETHOD.
-
 
   METHOD zif_logger~has_errors.
-
     rv_yes = boolc( lines( get_message_handles( msgtype = 'E' ) ) > 0 ).
-
   ENDMETHOD.
-
 
   METHOD zif_logger~has_warnings.
-
     rv_yes = boolc( lines( get_message_handles( msgtype = 'W' ) ) > 0 ).
-
   ENDMETHOD.
-
 
   METHOD zif_logger~i.
     self = add(
@@ -673,20 +633,13 @@ CLASS zcl_logger IMPLEMENTATION.
       importance          = importance ).
   ENDMETHOD.
 
-
   METHOD zif_logger~is_empty.
-
     rv_yes = boolc( length( ) = 0 ).
-
   ENDMETHOD.
-
 
   METHOD zif_logger~length.
-
     rv_length = lines( get_message_handles( ) ).
-
   ENDMETHOD.
-
 
   METHOD zif_logger~popup.
 * See SBAL_DEMO_04_POPUP for ideas
@@ -709,7 +662,6 @@ CLASS zcl_logger IMPLEMENTATION.
         i_t_log_handle      = lt_log_handles.
   ENDMETHOD.
 
-
   METHOD zif_logger~s.
     self = add(
       obj_to_log          = obj_to_log
@@ -722,12 +674,10 @@ CLASS zcl_logger IMPLEMENTATION.
       importance          = importance ).
   ENDMETHOD.
 
-
   METHOD zif_logger~save.
-    CHECK me->settings->get_autosave( ) = abap_false.
+    CHECK settings->get_autosave( ) = abap_false.
     save_log( ).
   ENDMETHOD.
-
 
   METHOD zif_logger~w.
     self = add(
@@ -740,7 +690,6 @@ CLASS zcl_logger IMPLEMENTATION.
       type                = 'W'
       importance          = importance ).
   ENDMETHOD.
-
 
   METHOD save_log.
     DATA log_handles TYPE bal_t_logh.
@@ -761,9 +710,7 @@ CLASS zcl_logger IMPLEMENTATION.
     ENDIF.
   ENDMETHOD.
 
-
   METHOD zif_logger~set_header.
-
     me->header-extnumber = description.
 
     CALL FUNCTION 'BAL_LOG_HDR_CHANGE'
@@ -777,7 +724,6 @@ CLASS zcl_logger IMPLEMENTATION.
     ASSERT sy-subrc = 0.
 
     self = me.
-
   ENDMETHOD.
 
 ENDCLASS.

--- a/src/zcl_logger.clas.testclasses.abap
+++ b/src/zcl_logger.clas.testclasses.abap
@@ -57,15 +57,11 @@ CLASS lcl_test DEFINITION FOR TESTING
       can_create_expiring_log_days FOR TESTING,
       can_create_expiring_log_date FOR TESTING,
       can_open_or_create FOR TESTING,
-
       can_add_log_context FOR TESTING,
-
       can_add_to_log FOR TESTING,
       can_add_to_named_log FOR TESTING,
-
       auto_saves_named_log FOR TESTING,
       auto_saves_reopened_log FOR TESTING,
-
       can_log_string FOR TESTING,
       can_log_char   FOR TESTING,
       can_log_symsg FOR TESTING,
@@ -83,15 +79,11 @@ CLASS lcl_test DEFINITION FOR TESTING
       can_log_any_simple_structure FOR TESTING,
       can_log_any_deep_structure FOR TESTING,
       can_log_loggable_object FOR TESTING,
-
       can_add_msg_context FOR TESTING,
       can_add_callback_sub FOR TESTING,
       can_add_callback_fm  FOR TESTING,
-
       must_use_factory FOR TESTING,
-
       can_use_and_chain_aliases FOR TESTING,
-
       return_proper_status FOR TESTING,
       return_proper_length FOR TESTING,
       can_add_table_msg_context FOR TESTING RAISING cx_static_check,
@@ -99,7 +91,7 @@ CLASS lcl_test DEFINITION FOR TESTING
       can_change_description FOR TESTING RAISING cx_static_check,
       can_log_callback_params FOR TESTING RAISING cx_static_check.
 
-ENDCLASS.       "lcl_Test
+ENDCLASS.
 
 CLASS lcl_test IMPLEMENTATION.
 
@@ -121,13 +113,13 @@ CLASS lcl_test IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD can_create_anon_log.
-    cl_aunit_assert=>assert_bound(
+    cl_abap_unit_assert=>assert_bound(
       act = anon_log
       msg = 'Cannot Instantiate Anonymous Log' ).
   ENDMETHOD.
 
   METHOD can_create_named_log.
-    cl_aunit_assert=>assert_bound(
+    cl_abap_unit_assert=>assert_bound(
       act = named_log
       msg = 'Cannot Instantiate Named Log' ).
   ENDMETHOD.
@@ -143,10 +135,9 @@ CLASS lcl_test IMPLEMENTATION.
       desc      = 'Log that is not deletable and expiring'
       settings  = zcl_logger_factory=>create_settings(
         )->set_expiry_in_days( days_until_log_can_be_deleted
-        )->set_must_be_kept_until_expiry( abap_true )
-    ).
+        )->set_must_be_kept_until_expiry( abap_true ) ).
 
-    cl_aunit_assert=>assert_bound(
+    cl_abap_unit_assert=>assert_bound(
       act = expiring_log
       msg = 'Cannot Instantiate Expiring Log' ).
 
@@ -159,19 +150,14 @@ CLASS lcl_test IMPLEMENTATION.
     DATA lv_exp TYPE d.
     lv_exp = sy-datum + days_until_log_can_be_deleted.
 
-    cl_aunit_assert=>assert_equals(
-      EXPORTING
-        exp     = lv_exp
-        act     = act_header-aldate_del
-        msg     = 'Log is not expiring in correct amount of days'
-    ).
-
-    cl_aunit_assert=>assert_equals(
-      EXPORTING
-        exp     = abap_true
-        act     = act_header-del_before
-        msg     = 'Log should not be deletable before expiry date'
-    ).
+    cl_abap_unit_assert=>assert_equals(
+      exp     = lv_exp
+      act     = act_header-aldate_del
+      msg     = 'Log is not expiring in correct amount of days' ).
+    cl_abap_unit_assert=>assert_equals(
+      exp     = abap_true
+      act     = act_header-del_before
+      msg     = 'Log should not be deletable before expiry date' ).
   ENDMETHOD.
 
   METHOD can_create_expiring_log_date.
@@ -188,10 +174,9 @@ CLASS lcl_test IMPLEMENTATION.
       desc      = 'Log that is not deletable and expiring'
       settings  = zcl_logger_factory=>create_settings(
         )->set_expiry_date( lv_expire
-        )->set_must_be_kept_until_expiry( abap_true )
-    ).
+        )->set_must_be_kept_until_expiry( abap_true ) ).
 
-    cl_aunit_assert=>assert_bound(
+    cl_abap_unit_assert=>assert_bound(
       act = expiring_log
       msg = 'Cannot Instantiate Expiring Log' ).
 
@@ -201,23 +186,18 @@ CLASS lcl_test IMPLEMENTATION.
       IMPORTING
         e_s_log      = act_header.
 
-    cl_aunit_assert=>assert_equals(
-      EXPORTING
-        exp     = lv_expire
-        act     = act_header-aldate_del
-        msg     = 'Log is not expiring on correct date'
-    ).
-
-    cl_aunit_assert=>assert_equals(
-      EXPORTING
-        exp     = abap_true
-        act     = act_header-del_before
-        msg     = 'Log should not be deletable before expiry date'
-    ).
+    cl_abap_unit_assert=>assert_equals(
+      exp     = lv_expire
+      act     = act_header-aldate_del
+      msg     = 'Log is not expiring on correct date' ).
+    cl_abap_unit_assert=>assert_equals(
+      exp     = abap_true
+      act     = act_header-del_before
+      msg     = 'Log should not be deletable before expiry date' ).
   ENDMETHOD.
 
   METHOD can_reopen_log.
-    cl_aunit_assert=>assert_bound(
+    cl_abap_unit_assert=>assert_bound(
       act = reopened_log
       msg = 'Cannot Reopen Log from DB' ).
   ENDMETHOD.
@@ -238,15 +218,13 @@ CLASS lcl_test IMPLEMENTATION.
       IMPORTING
         e_t_log_handle = handles.
 
-    cl_aunit_assert=>assert_equals(
+    cl_abap_unit_assert=>assert_equals(
       exp = 2
       act = lines( handles )
       msg = 'Did not create nonexistent log from OPEN' ).
-
   ENDMETHOD.
 
   METHOD can_add_log_context.
-
     DATA: log                 TYPE REF TO zif_logger,
           random_country_data TYPE t005t,
           act_header          TYPE bal_s_log.
@@ -263,29 +241,25 @@ CLASS lcl_test IMPLEMENTATION.
       IMPORTING
         e_s_log      = act_header.
 
-    cl_aunit_assert=>assert_equals(
+    cl_abap_unit_assert=>assert_equals(
       exp = 'T005T'
       act = act_header-context-tabname
       msg = 'Did not add context to log' ).
-
-    cl_aunit_assert=>assert_equals(
+    cl_abap_unit_assert=>assert_equals(
       exp = random_country_data
       act = act_header-context-value
       msg = 'Did not add context to log' ).
-
   ENDMETHOD.
 
   METHOD can_add_to_log.
     DATA: dummy TYPE c.
-
     MESSAGE s001(00) WITH 'I' 'test' 'the' 'logger.' INTO dummy.
     anon_log->add( ).
 
-    cl_aunit_assert=>assert_equals(
+    cl_abap_unit_assert=>assert_equals(
       exp = 'Itestthelogger.'
       act = get_first_message( anon_log->handle )
       msg = 'Did not log system message properly' ).
-
   ENDMETHOD.
 
   METHOD can_add_to_named_log.
@@ -294,12 +268,11 @@ CLASS lcl_test IMPLEMENTATION.
     MESSAGE s001(00) WITH 'Testing' 'a' 'named' 'logger.' INTO dummy.
     named_log->add( ).
 
-    cl_aunit_assert=>assert_equals(
+    cl_abap_unit_assert=>assert_equals(
       exp = 'Testinganamedlogger.'
       act = get_first_message( named_log->handle )
       msg = 'Did not write to named log' ).
   ENDMETHOD.
-
 
   METHOD auto_saves_named_log.
     DATA: dummy       TYPE c,
@@ -317,11 +290,10 @@ CLASS lcl_test IMPLEMENTATION.
       EXPORTING
         i_t_lognumber = log_numbers.
 
-    cl_aunit_assert=>assert_equals(
+    cl_abap_unit_assert=>assert_equals(
       exp = msg
       act = get_first_message( named_log->handle )
       msg = 'Did not write to named log' ).
-
   ENDMETHOD.
 
   METHOD auto_saves_reopened_log.
@@ -340,35 +312,33 @@ CLASS lcl_test IMPLEMENTATION.
                   IMPORTING texts       = act_texts ).
 
     READ TABLE act_texts INDEX 1 INTO act_text.
-    cl_aunit_assert=>assert_equals(
+    cl_abap_unit_assert=>assert_equals(
       exp = 'This message is in the database'
       act = act_text
       msg = 'Did not autosave to reopened log' ).
 
     READ TABLE act_texts INDEX 2 INTO act_text.
-    cl_aunit_assert=>assert_equals(
+    cl_abap_unit_assert=>assert_equals(
       exp = 'This is another message in the database'
       act = act_text
       msg = 'Did not autosave to reopened log' ).
-
   ENDMETHOD.
 
   METHOD can_log_string.
     DATA: stringmessage TYPE string VALUE `Logging a string, guys!`.
     anon_log->add( stringmessage ).
 
-    cl_aunit_assert=>assert_equals(
+    cl_abap_unit_assert=>assert_equals(
       exp = stringmessage
       act = get_first_message( anon_log->handle )
       msg = 'Did not log system message properly' ).
-
   ENDMETHOD.
 
   METHOD can_log_char.
     DATA: charmessage TYPE char70 VALUE 'Logging a char sequence!'.
     anon_log->add( charmessage ).
 
-    cl_aunit_assert=>assert_equals(
+    cl_abap_unit_assert=>assert_equals(
       exp = charmessage
       act = get_first_message( anon_log->handle )
       msg = 'Did not log system message properly' ).
@@ -401,29 +371,25 @@ CLASS lcl_test IMPLEMENTATION.
         e_s_msg        = actual_details
         e_txt_msg      = actual_text.
 
-    cl_aunit_assert=>assert_not_initial(
+    cl_abap_unit_assert=>assert_not_initial(
       act = actual_details-time_stmp
       msg = 'Did not log system message properly' ).
 
     expected_details-msg_count = 1.
     CLEAR actual_details-time_stmp.
 
-    cl_aunit_assert=>assert_equals(
+    cl_abap_unit_assert=>assert_equals(
       exp = expected_details
       act = actual_details
       msg = 'Did not log system message properly' ).
-
-    cl_aunit_assert=>assert_equals(
+    cl_abap_unit_assert=>assert_equals(
       exp = 'This is a test'
       act = condense( actual_text )
       msg = 'Did not log system message properly' ).
-
-    cl_aunit_assert=>assert_equals(
+    cl_abap_unit_assert=>assert_equals(
       exp = abap_true
       act = anon_log->has_warnings( )
-      msg = 'Did not log or fetch system message properly'
-    ).
-
+      msg = 'Did not log or fetch system message properly' ).
   ENDMETHOD.
 
   METHOD can_log_bapiret1.
@@ -453,29 +419,25 @@ CLASS lcl_test IMPLEMENTATION.
         e_s_msg        = actual_details
         e_txt_msg      = actual_text.
 
-    cl_aunit_assert=>assert_not_initial(
+    cl_abap_unit_assert=>assert_not_initial(
       act = actual_details-time_stmp
       msg = 'Did not log system message properly' ).
 
     expected_details-msg_count = 1.
     CLEAR actual_details-time_stmp.
 
-    cl_aunit_assert=>assert_equals(
+    cl_abap_unit_assert=>assert_equals(
       exp = expected_details
       act = actual_details
       msg = 'Did not log system message properly' ).
-
-    cl_aunit_assert=>assert_equals(
+    cl_abap_unit_assert=>assert_equals(
       exp = 'This is a test'
       act = condense( actual_text )
       msg = 'Did not log system message properly' ).
-
-    cl_aunit_assert=>assert_equals(
+    cl_abap_unit_assert=>assert_equals(
       exp = abap_true
       act = anon_log->has_warnings( )
-      msg = 'Did not log or fetch system message properly'
-    ).
-
+      msg = 'Did not log or fetch system message properly' ).
   ENDMETHOD.
 
   METHOD can_log_bapiret2.
@@ -505,28 +467,27 @@ CLASS lcl_test IMPLEMENTATION.
         e_s_msg        = actual_details
         e_txt_msg      = actual_text.
 
-    cl_aunit_assert=>assert_not_initial(
+    cl_abap_unit_assert=>assert_not_initial(
       act = actual_details-time_stmp
       msg = 'Did not log system message properly' ).
 
     expected_details-msg_count = 1.
     CLEAR actual_details-time_stmp.
 
-    cl_aunit_assert=>assert_equals(
+    cl_abap_unit_assert=>assert_equals(
       exp = expected_details
       act = actual_details
       msg = 'Did not log system message properly' ).
 
-    cl_aunit_assert=>assert_equals(
+    cl_abap_unit_assert=>assert_equals(
       exp = 'This is a test'
       act = condense( actual_text )
       msg = 'Did not log system message properly' ).
 
-    cl_aunit_assert=>assert_equals(
+    cl_abap_unit_assert=>assert_equals(
       exp = abap_true
       act = anon_log->has_warnings( )
-      msg = 'Did not log or fetch system message properly'
-    ).
+      msg = 'Did not log or fetch system message properly' ).
   ENDMETHOD.
 
   METHOD can_log_bapi_coru_return.
@@ -556,28 +517,25 @@ CLASS lcl_test IMPLEMENTATION.
         e_s_msg        = actual_details
         e_txt_msg      = actual_text.
 
-    cl_aunit_assert=>assert_not_initial(
+    cl_abap_unit_assert=>assert_not_initial(
       act = actual_details-time_stmp
       msg = 'Did not log system message properly' ).
 
     expected_details-msg_count = 1.
     CLEAR actual_details-time_stmp.
 
-    cl_aunit_assert=>assert_equals(
+    cl_abap_unit_assert=>assert_equals(
       exp = expected_details
       act = actual_details
       msg = 'Did not log system message properly' ).
-
-    cl_aunit_assert=>assert_equals(
+    cl_abap_unit_assert=>assert_equals(
       exp = 'This is a test'
       act = condense( actual_text )
       msg = 'Did not log system message properly' ).
-
-    cl_aunit_assert=>assert_equals(
+    cl_abap_unit_assert=>assert_equals(
       exp = abap_true
       act = anon_log->has_warnings( )
-      msg = 'Did not log or fetch system message properly'
-    ).
+      msg = 'Did not log or fetch system message properly' ).
   ENDMETHOD.
 
   METHOD can_log_bapi_order_return.
@@ -617,28 +575,27 @@ CLASS lcl_test IMPLEMENTATION.
         e_s_msg        = actual_details
         e_txt_msg      = actual_text.
 
-    cl_aunit_assert=>assert_not_initial(
+    cl_abap_unit_assert=>assert_not_initial(
       act = actual_details-time_stmp
       msg = 'Did not log system message properly' ).
 
     expected_details-msg_count = 1.
     CLEAR actual_details-time_stmp.
 
-    cl_aunit_assert=>assert_equals(
+    cl_abap_unit_assert=>assert_equals(
       exp = expected_details
       act = actual_details
       msg = 'Did not log system message properly' ).
 
-    cl_aunit_assert=>assert_equals(
+    cl_abap_unit_assert=>assert_equals(
       exp = 'This is a test'
       act = condense( actual_text )
       msg = 'Did not log system message properly' ).
 
-    cl_aunit_assert=>assert_equals(
+    cl_abap_unit_assert=>assert_equals(
       exp = abap_true
       act = anon_log->has_errors( )
-      msg = 'Did not log or fetch system message properly'
-    ).
+      msg = 'Did not log or fetch system message properly' ).
   ENDMETHOD.
 
   METHOD can_log_rcomp.
@@ -680,28 +637,27 @@ CLASS lcl_test IMPLEMENTATION.
         e_s_msg        = actual_details
         e_txt_msg      = actual_text.
 
-    cl_aunit_assert=>assert_not_initial(
+    cl_abap_unit_assert=>assert_not_initial(
       act = actual_details-time_stmp
       msg = 'Did not log system message properly' ).
 
     expected_details-msg_count = 1.
     CLEAR actual_details-time_stmp.
 
-    cl_aunit_assert=>assert_equals(
+    cl_abap_unit_assert=>assert_equals(
       exp = expected_details
       act = actual_details
       msg = 'Did not log system message properly' ).
 
-    cl_aunit_assert=>assert_equals(
+    cl_abap_unit_assert=>assert_equals(
       exp = 'This is a test'
       act = condense( actual_text )
       msg = 'Did not log system message properly' ).
 
-    cl_aunit_assert=>assert_equals(
+    cl_abap_unit_assert=>assert_equals(
       exp = abap_true
       act = anon_log->has_errors( )
-      msg = 'Did not log or fetch system message properly'
-    ).
+      msg = 'Did not log or fetch system message properly' ).
   ENDMETHOD.
 
   METHOD can_log_prott.
@@ -743,32 +699,28 @@ CLASS lcl_test IMPLEMENTATION.
         e_s_msg        = actual_details
         e_txt_msg      = actual_text.
 
-    cl_aunit_assert=>assert_not_initial(
+    cl_abap_unit_assert=>assert_not_initial(
       act = actual_details-time_stmp
       msg = 'Did not log system message properly' ).
 
     expected_details-msg_count = 1.
     CLEAR actual_details-time_stmp.
 
-    cl_aunit_assert=>assert_equals(
+    cl_abap_unit_assert=>assert_equals(
       exp = expected_details
       act = actual_details
       msg = 'Did not log system message properly' ).
-
-    cl_aunit_assert=>assert_equals(
+    cl_abap_unit_assert=>assert_equals(
       exp = 'This is a test'
       act = condense( actual_text )
       msg = 'Did not log system message properly' ).
-
-    cl_aunit_assert=>assert_equals(
+    cl_abap_unit_assert=>assert_equals(
       exp = abap_true
       act = anon_log->has_warnings( )
-      msg = 'Did not log or fetch system message properly'
-    ).
+      msg = 'Did not log or fetch system message properly' ).
   ENDMETHOD.
 
   METHOD can_log_sprot.
-
     DATA: sprot_msg        TYPE pat_sprot,
           msg_handle       TYPE balmsghndl,
           expected_details TYPE bal_s_msg,
@@ -795,28 +747,25 @@ CLASS lcl_test IMPLEMENTATION.
         e_s_msg        = actual_details
         e_txt_msg      = actual_text.
 
-    cl_aunit_assert=>assert_not_initial(
+    cl_abap_unit_assert=>assert_not_initial(
       act = actual_details-time_stmp
       msg = 'Did not log system message properly' ).
 
     expected_details-msg_count = 1.
     CLEAR actual_details-time_stmp.
 
-    cl_aunit_assert=>assert_equals(
+    cl_abap_unit_assert=>assert_equals(
       exp = expected_details
       act = actual_details
       msg = 'Did not log system message properly' ).
-
-    cl_aunit_assert=>assert_equals(
+    cl_abap_unit_assert=>assert_equals(
       exp = 'This is a test'
       act = condense( actual_text )
       msg = 'Did not log system message properly' ).
-
-    cl_aunit_assert=>assert_equals(
+    cl_abap_unit_assert=>assert_equals(
       exp = abap_true
       act = anon_log->has_warnings( )
-      msg = 'Did not log or fetch system message properly'
-    ).
+      msg = 'Did not log or fetch system message properly' ).
   ENDMETHOD.
 
   METHOD can_log_bapirettab.
@@ -860,21 +809,21 @@ CLASS lcl_test IMPLEMENTATION.
       READ TABLE act_details INTO act_detail INDEX sy-index.
       READ TABLE exp_details INTO exp_detail INDEX sy-index.
 
-      cl_aunit_assert=>assert_not_initial(
+      cl_abap_unit_assert=>assert_not_initial(
         act = act_detail-time_stmp
         msg = 'Did not log system message properly' ).
 
       exp_detail-msg_count = 1.
       CLEAR act_detail-time_stmp.
 
-      cl_aunit_assert=>assert_equals(
+      cl_abap_unit_assert=>assert_equals(
         exp = exp_detail
         act = act_detail
         msg = 'Did not log bapirettab properly' ).
 
       READ TABLE act_texts INTO act_text INDEX sy-index.
       READ TABLE exp_texts INTO exp_text INDEX sy-index.
-      cl_aunit_assert=>assert_equals(
+      cl_abap_unit_assert=>assert_equals(
         exp = exp_text
         act = condense( act_text )
         msg = 'Did not log bapirettab properly' ).
@@ -906,15 +855,13 @@ CLASS lcl_test IMPLEMENTATION.
       IMPORTING
         e_txt_msg      = act_txt.
 
-    cl_aunit_assert=>assert_equals(
+    cl_abap_unit_assert=>assert_equals(
       exp = exp_txt "'Division by zero'
       act = act_txt
       msg = 'Did not log throwable correctly' ).
-
   ENDMETHOD.
 
   METHOD can_log_chained_exceptions.
-
     CONSTANTS c_chained_exception TYPE string VALUE 'Did not log chained exception correctly'.
 
     DATA: main_exception     TYPE REF TO lcx_t100,
@@ -978,12 +925,9 @@ CLASS lcl_test IMPLEMENTATION.
       exp = 'SABP_UNIT000Thisistestmessage'                " 'Message: This is test message'
       act = bal_msg-msgid && bal_msg-msgno && bal_msg-msgv1 && bal_msg-msgv2 && bal_msg-msgv3 && bal_msg-msgv4
       msg = c_chained_exception ).
-
   ENDMETHOD.
 
-
   METHOD can_log_batch_msgs.
-
     CONSTANTS c_bdc_message TYPE string VALUE 'Did not log BDC return messages correctly'.
 
     DATA: batch_msgs TYPE TABLE OF bdcmsgcoll,
@@ -1014,7 +958,7 @@ CLASS lcl_test IMPLEMENTATION.
                   IMPORTING msg_details = bal_msgs ).
 
     DESCRIBE TABLE bal_msgs LINES msg_count.
-    cl_aunit_assert=>assert_equals(
+    cl_abap_unit_assert=>assert_equals(
       exp = 3
       act = msg_count
       msg = c_bdc_message ).
@@ -1036,9 +980,7 @@ CLASS lcl_test IMPLEMENTATION.
       exp = 'SABP_UNIT000Thisistestmessage'                " 'Message: This is test message'
       act = bal_msg-msgid && bal_msg-msgno && bal_msg-msgv1 && bal_msg-msgv2 && bal_msg-msgv3 && bal_msg-msgv4
       msg = c_bdc_message ).
-
   ENDMETHOD.
-
 
   METHOD can_log_any_simple_structure.
     TYPES: BEGIN OF ty_struct,
@@ -1068,13 +1010,11 @@ CLASS lcl_test IMPLEMENTATION.
     exp_line = '--- End of structure ---'.
     APPEND exp_line TO exp_table.
 
-    cl_aunit_assert=>assert_equals(
+    cl_abap_unit_assert=>assert_equals(
       exp = exp_table
       act = act_table
-      msg = 'Simple structure was not logged correctly'
-    ).
+      msg = 'Simple structure was not logged correctly' ).
   ENDMETHOD.
-
 
   METHOD can_log_any_deep_structure.
     TYPES: BEGIN OF ty_struct,
@@ -1115,13 +1055,11 @@ CLASS lcl_test IMPLEMENTATION.
     exp_line = '--- End of structure ---'.
     APPEND exp_line TO exp_table.
 
-    cl_aunit_assert=>assert_equals(
+    cl_abap_unit_assert=>assert_equals(
       exp = exp_table
       act = act_table
-      msg = 'Deep structure was not logged correctly'
-    ).
+      msg = 'Deep structure was not logged correctly' ).
   ENDMETHOD.
-
 
   METHOD can_add_msg_context.
     DATA: addl_context TYPE bezei20 VALUE 'Berlin',        "data element from dictionary!
@@ -1139,24 +1077,24 @@ CLASS lcl_test IMPLEMENTATION.
       IMPORTING
         e_s_msg        = act_details.
 
-    cl_aunit_assert=>assert_equals(
+    cl_abap_unit_assert=>assert_equals(
       exp = addl_context
       act = act_details-context-value
       msg = 'Did not add context correctly' ).
-    cl_aunit_assert=>assert_equals(
+    cl_abap_unit_assert=>assert_equals(
       exp = 'BEZEI20'
       act = act_details-context-tabname
       msg = 'Did not add context correctly' ).
-
   ENDMETHOD.
 
 
   METHOD can_log_loggable_object.
     "given
     DATA loggable_message TYPE zif_loggable_object=>ty_message.
-    DATA loggable         TYPE REF TO ltd_loggable_object.
     DATA dummy            TYPE string.
-    CREATE OBJECT loggable TYPE ltd_loggable_object.
+
+    DATA loggable         TYPE REF TO ltd_loggable_object.
+    loggable = NEW ltd_loggable_object( ).
 
     MESSAGE s001(00) WITH 'I' 'test' 'the' 'logger.' INTO dummy.
     MOVE-CORRESPONDING sy TO loggable_message-symsg.
@@ -1167,12 +1105,11 @@ CLASS lcl_test IMPLEMENTATION.
     named_log->add( obj_to_log = loggable ).
 
     "then
-    cl_aunit_assert=>assert_equals(
+    cl_abap_unit_assert=>assert_equals(
       exp = 'Itestthelogger.'
       act = get_first_message( named_log->handle )
       msg = 'Did not add loggable message correctly' ).
   ENDMETHOD.
-
 
   METHOD can_add_table_msg_context.
     DATA: addl_context TYPE bezei20 VALUE 'Berlin',        "data element from dictionary!
@@ -1195,15 +1132,14 @@ CLASS lcl_test IMPLEMENTATION.
       IMPORTING
         e_s_msg        = act_details.
 
-    cl_aunit_assert=>assert_equals(
+    cl_abap_unit_assert=>assert_equals(
       exp = addl_context
       act = act_details-context-value
       msg = 'Did not add context correctly' ).
-    cl_aunit_assert=>assert_equals(
+    cl_abap_unit_assert=>assert_equals(
       exp = 'BEZEI20'
       act = act_details-context-tabname
       msg = 'Did not add context correctly' ).
-
 
     msg_handle-msgnumber  = '000002'.
     CALL FUNCTION 'BAL_LOG_MSG_READ'
@@ -1212,11 +1148,10 @@ CLASS lcl_test IMPLEMENTATION.
       IMPORTING
         e_s_msg        = act_details.
 
-    cl_aunit_assert=>assert_initial(
+    cl_abap_unit_assert=>assert_initial(
         act = act_details-context-value
         msg = 'Context should only be added to first line'  ).
-
-    cl_aunit_assert=>assert_initial(
+    cl_abap_unit_assert=>assert_initial(
         act = act_details-context-tabname
         msg = 'Context should only be added to first line'  ).
   ENDMETHOD.
@@ -1243,11 +1178,10 @@ CLASS lcl_test IMPLEMENTATION.
     exp_callback-userexitp = 'PROGRAM'.
     exp_callback-userexitt = ' '.
 
-    cl_aunit_assert=>assert_equals(
+    cl_abap_unit_assert=>assert_equals(
       exp = exp_callback
       act = msg_detail-params-callback
       msg = 'Did not add callback correctly' ).
-
   ENDMETHOD.
 
   METHOD can_add_callback_fm.
@@ -1271,7 +1205,7 @@ CLASS lcl_test IMPLEMENTATION.
     exp_callback-userexitp = ' '.
     exp_callback-userexitt = 'F'.
 
-    cl_aunit_assert=>assert_equals(
+    cl_abap_unit_assert=>assert_equals(
       exp = exp_callback
       act = msg_detail-params-callback
       msg = 'Did not add callback correctly' ).
@@ -1281,7 +1215,7 @@ CLASS lcl_test IMPLEMENTATION.
     DATA: log TYPE REF TO object.
     TRY.
         CREATE OBJECT log TYPE ('ZCL_LOGGER').
-        cl_aunit_assert=>fail( 'Did not force creation via factory' ).
+        cl_abap_unit_assert=>fail( 'Did not force creation via factory' ).
       CATCH cx_sy_create_object_error.
         "PASSED
     ENDTRY.
@@ -1302,55 +1236,54 @@ CLASS lcl_test IMPLEMENTATION.
                             msg_details = msg_details ).
     READ TABLE texts INDEX 1 INTO text.
     READ TABLE msg_details INDEX 1 INTO msg_detail.
-    cl_aunit_assert=>assert_equals(
+    cl_abap_unit_assert=>assert_equals(
       exp = 'A'
       act = msg_detail-msgty
       msg = 'Didn''t log by alias' ).
-    cl_aunit_assert=>assert_equals(
+    cl_abap_unit_assert=>assert_equals(
       exp = 'Severe Abort Error!'
       act = text
       msg = 'Didn''t log by alias' ).
     READ TABLE texts INDEX 2 INTO text.
     READ TABLE msg_details INDEX 2 INTO msg_detail.
-    cl_aunit_assert=>assert_equals(
+    cl_abap_unit_assert=>assert_equals(
       exp = 'E'
       act = msg_detail-msgty
       msg = 'Didn''t log by alias' ).
-    cl_aunit_assert=>assert_equals(
+    cl_abap_unit_assert=>assert_equals(
       exp = 'Here''s an error!'
       act = text
       msg = 'Didn''t log by alias' ).
     READ TABLE texts INDEX 3 INTO text.
     READ TABLE msg_details INDEX 3 INTO msg_detail.
-    cl_aunit_assert=>assert_equals(
+    cl_abap_unit_assert=>assert_equals(
       exp = 'W'
       act = msg_detail-msgty
       msg = 'Didn''t log by alias' ).
-    cl_aunit_assert=>assert_equals(
+    cl_abap_unit_assert=>assert_equals(
       exp = 'This is a warning'
       act = text
       msg = 'Didn''t log by alias' ).
     READ TABLE texts INDEX 4 INTO text.
     READ TABLE msg_details INDEX 4 INTO msg_detail.
-    cl_aunit_assert=>assert_equals(
+    cl_abap_unit_assert=>assert_equals(
       exp = 'I'
       act = msg_detail-msgty
       msg = 'Didn''t log by alias' ).
-    cl_aunit_assert=>assert_equals(
+    cl_abap_unit_assert=>assert_equals(
       exp = 'Helpful Information'
       act = text
       msg = 'Didn''t log by alias' ).
     READ TABLE texts INDEX 5 INTO text.
     READ TABLE msg_details INDEX 5 INTO msg_detail.
-    cl_aunit_assert=>assert_equals(
+    cl_abap_unit_assert=>assert_equals(
       exp = 'S'
       act = msg_detail-msgty
       msg = 'Didn''t log by alias' ).
-    cl_aunit_assert=>assert_equals(
+    cl_abap_unit_assert=>assert_equals(
       exp = 'GreatSuccess'
       act = text
       msg = 'Didn''t log by alias' ).
-
   ENDMETHOD.
 
   METHOD get_first_message.
@@ -1366,7 +1299,6 @@ CLASS lcl_test IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD get_messages.
-
     DATA: handle_as_table TYPE bal_t_logh,
           message_handles TYPE bal_t_msgh,
           msg_handle      TYPE balmsghndl,
@@ -1390,7 +1322,6 @@ CLASS lcl_test IMPLEMENTATION.
       APPEND msg_detail TO msg_details.
       APPEND msg_text TO texts.
     ENDLOOP.
-
   ENDMETHOD.
 
   METHOD format_message.
@@ -1416,42 +1347,36 @@ CLASS lcl_test IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD return_proper_status.
-
-    cl_aunit_assert=>assert_not_initial(
+    cl_abap_unit_assert=>assert_not_initial(
       act = anon_log->is_empty( )
       msg = 'Not empty at start' ).
 
     anon_log->s( 'success' ).
     anon_log->i( 'info' ).
 
-    cl_aunit_assert=>assert_initial(
+    cl_abap_unit_assert=>assert_initial(
       act = anon_log->is_empty( )
       msg = 'Empty after add' ).
-
-    cl_aunit_assert=>assert_initial(
+    cl_abap_unit_assert=>assert_initial(
       act = anon_log->has_errors( )
       msg = 'Has errors when there were no errors' ).
-
-    cl_aunit_assert=>assert_initial(
+    cl_abap_unit_assert=>assert_initial(
       act = anon_log->has_warnings( )
       msg = 'Has warnings when there were no warnings' ).
 
     anon_log->e( 'error' ).
     anon_log->w( 'warning' ).
 
-    cl_aunit_assert=>assert_not_initial(
+    cl_abap_unit_assert=>assert_not_initial(
       act = anon_log->has_errors( )
       msg = 'Has no errors when there were errors' ).
-
-    cl_aunit_assert=>assert_not_initial(
+    cl_abap_unit_assert=>assert_not_initial(
       act = anon_log->has_warnings( )
       msg = 'Has no warnings when there were warnings' ).
-
   ENDMETHOD.
 
   METHOD return_proper_length.
-
-    cl_aunit_assert=>assert_equals(
+    cl_abap_unit_assert=>assert_equals(
       exp = 0
       act = anon_log->length( )
       msg = 'Did not return 0 length at start' ).
@@ -1460,16 +1385,13 @@ CLASS lcl_test IMPLEMENTATION.
     anon_log->i( 'info' ).
     anon_log->w( 'warning' ).
 
-    cl_aunit_assert=>assert_equals(
+    cl_abap_unit_assert=>assert_equals(
       exp = 3
       act = anon_log->length( )
       msg = 'Did not return right length after add' ).
-
   ENDMETHOD.
 
-
   METHOD can_log_string_and_export.
-
     DATA: stringmessage TYPE string VALUE `Logging a string, guys!`,
           table         TYPE bapirettab.
 
@@ -1477,12 +1399,11 @@ CLASS lcl_test IMPLEMENTATION.
 
     table = anon_log->export_to_table( ).
 
-    cl_aunit_assert=>assert_equals(
+    cl_abap_unit_assert=>assert_equals(
       exp = 1
       act = lines( table )
       msg = 'Did not log system message properly' ).
   ENDMETHOD.
-
 
   METHOD can_change_description.
 
@@ -1516,12 +1437,9 @@ CLASS lcl_test IMPLEMENTATION.
         exp = desc
         act = reopened_log->header-extnumber
         msg = 'Did not return new desc' ).
-
   ENDMETHOD.
 
-
   METHOD can_log_callback_params.
-
     DATA:
       callback_parameters TYPE bal_t_par,
       parameter           LIKE LINE OF callback_parameters,
@@ -1575,8 +1493,6 @@ CLASS lcl_test IMPLEMENTATION.
           act = <detail>-params-t_par ).
 
     ENDLOOP.
-
   ENDMETHOD.
 
-
-ENDCLASS.       "lcl_Test
+ENDCLASS.

--- a/src/zcl_logger.clas.testclasses.abap
+++ b/src/zcl_logger.clas.testclasses.abap
@@ -1094,7 +1094,7 @@ CLASS lcl_test IMPLEMENTATION.
     DATA dummy            TYPE string.
 
     DATA loggable         TYPE REF TO ltd_loggable_object.
-    loggable = NEW ltd_loggable_object( ).
+    CREATE OBJECT loggable.
 
     MESSAGE s001(00) WITH 'I' 'test' 'the' 'logger.' INTO dummy.
     MOVE-CORRESPONDING sy TO loggable_message-symsg.

--- a/src/zcl_logger_collection.clas.abap
+++ b/src/zcl_logger_collection.clas.abap
@@ -39,8 +39,7 @@ CLASS zcl_logger_collection IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD zif_logger_collection~display_logs_using_profile.
-
-    DATA  log_handles  TYPE bal_t_logh  .
+    DATA  log_handles  TYPE bal_t_logh.
     log_handles = get_log_handles( ).
 
     CALL FUNCTION 'BAL_DSP_LOG_DISPLAY'
@@ -57,32 +56,27 @@ CLASS zcl_logger_collection IMPLEMENTATION.
       "Todo "Raise Exception Error?
       MESSAGE ID sy-msgid TYPE 'S' NUMBER sy-msgno
         WITH sy-msgv1 sy-msgv2 sy-msgv3 sy-msgv4 DISPLAY LIKE sy-msgty.
-    ENDIF .
-
+    ENDIF.
   ENDMETHOD.
 
   METHOD get_log_handles.
-
     DATA logger TYPE REF TO zif_logger.
     LOOP AT loggers INTO logger.
       INSERT logger->handle INTO TABLE r_return.
     ENDLOOP.
-
   ENDMETHOD.
 
   METHOD get_display_profile.
-
     CALL FUNCTION 'BAL_DSP_PROFILE_STANDARD_GET'
       IMPORTING
         e_s_display_profile = r_return.
 
-    r_return-head_size = display_profile_head_size .
-    r_return-tree_size = display_profile_tree_size .
+    r_return-head_size = display_profile_head_size.
+    r_return-tree_size = display_profile_tree_size.
     "interesting fact - I can't remember why I needed to move the hidden columns....
     IF r_return-mess_fcat IS NOT INITIAL.
       SORT r_return-mess_fcat BY no_out ASCENDING col_pos DESCENDING.
     ENDIF.
-
   ENDMETHOD.
 
 ENDCLASS.

--- a/src/zcl_logger_collection.clas.abap
+++ b/src/zcl_logger_collection.clas.abap
@@ -30,7 +30,7 @@ CLASS zcl_logger_collection IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD zif_logger_collection~display_logs.
-    DATA  display_profile  TYPE bal_s_prof.
+    DATA display_profile TYPE bal_s_prof.
     display_profile = get_display_profile(
       display_profile_head_size = display_profile_head_size
       display_profile_tree_size = display_profile_tree_size ).
@@ -39,7 +39,7 @@ CLASS zcl_logger_collection IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD zif_logger_collection~display_logs_using_profile.
-    DATA  log_handles  TYPE bal_t_logh.
+    DATA log_handles TYPE bal_t_logh.
     log_handles = get_log_handles( ).
 
     CALL FUNCTION 'BAL_DSP_LOG_DISPLAY'

--- a/src/zcl_logger_display_profile.clas.abap
+++ b/src/zcl_logger_display_profile.clas.abap
@@ -12,9 +12,9 @@ CLASS zcl_logger_display_profile DEFINITION
 
     METHODS get_structure_components
       IMPORTING
-        i_structure_name   TYPE clike
+        i_structure_name    TYPE clike
       RETURNING
-        VALUE(r_components) TYPE cl_abap_structdescr=>component_table .
+        VALUE(r_components) TYPE cl_abap_structdescr=>component_table.
 ENDCLASS.
 
 

--- a/src/zcl_logger_display_profile.clas.abap
+++ b/src/zcl_logger_display_profile.clas.abap
@@ -12,31 +12,24 @@ CLASS zcl_logger_display_profile DEFINITION
 
     METHODS get_structure_components
       IMPORTING
-        !i_structure_name   TYPE clike
+        i_structure_name   TYPE clike
       RETURNING
         VALUE(r_components) TYPE cl_abap_structdescr=>component_table .
 ENDCLASS.
 
 
 
-CLASS ZCL_LOGGER_DISPLAY_PROFILE IMPLEMENTATION.
-
+CLASS zcl_logger_display_profile IMPLEMENTATION.
 
   METHOD get_structure_components.
-
     DATA strucdescr TYPE REF TO cl_abap_structdescr.
     strucdescr ?= cl_abap_structdescr=>describe_by_name( i_structure_name ).
     r_components = strucdescr->get_components( ).
-
   ENDMETHOD.
-
 
   METHOD zif_logger_display_profile~get.
-
     r_display_profile = display_profile.
-
   ENDMETHOD.
-
 
   METHOD zif_logger_display_profile~set.
     CASE abap_true.
@@ -65,9 +58,7 @@ CLASS ZCL_LOGGER_DISPLAY_PROFILE IMPLEMENTATION.
     r_self = me.
   ENDMETHOD.
 
-
   METHOD zif_logger_display_profile~set_context_message.
-
     CHECK display_profile IS NOT INITIAL.
 
     DATA colpos     TYPE i VALUE 100.
@@ -87,12 +78,9 @@ CLASS ZCL_LOGGER_DISPLAY_PROFILE IMPLEMENTATION.
       colpos = colpos + 1.
 
     ENDLOOP.
-
   ENDMETHOD.
 
-
   METHOD zif_logger_display_profile~set_context_tree.
-
     FIELD-SYMBOLS <lev1_fcat> TYPE bal_t_fcat.
     FIELD-SYMBOLS <lev2_fcat> TYPE bal_t_fcat.
     FIELD-SYMBOLS <lev1_sort> TYPE bal_t_sort.
@@ -116,7 +104,6 @@ CLASS ZCL_LOGGER_DISPLAY_PROFILE IMPLEMENTATION.
     CLEAR <lev1_sort>.
     CLEAR <lev2_sort>.
 
-
     DATA colpos     TYPE i VALUE 100.
     DATA sortpos    TYPE i VALUE 1.
     DATA lev_fcat   LIKE LINE OF display_profile-lev1_fcat.
@@ -127,7 +114,6 @@ CLASS ZCL_LOGGER_DISPLAY_PROFILE IMPLEMENTATION.
     components = get_structure_components( i_context_structure ).
 
     LOOP AT components INTO component.
-
       CLEAR lev_fcat.
 
       lev_fcat-ref_table = i_context_structure.
@@ -145,7 +131,6 @@ CLASS ZCL_LOGGER_DISPLAY_PROFILE IMPLEMENTATION.
       APPEND lev_sort TO <lev1_sort>.
 
       sortpos = sortpos + 1.
-
     ENDLOOP.
 
     CLEAR lev_fcat.
@@ -160,9 +145,7 @@ CLASS ZCL_LOGGER_DISPLAY_PROFILE IMPLEMENTATION.
     lev_sort-up        = 'X'.
     lev_sort-spos      = 1.
     APPEND lev_sort TO <lev2_sort>.
-
   ENDMETHOD.
-
 
   METHOD zif_logger_display_profile~set_grid.
     zif_logger_display_profile~set_value(
@@ -172,9 +155,7 @@ CLASS ZCL_LOGGER_DISPLAY_PROFILE IMPLEMENTATION.
     r_self = me.
   ENDMETHOD.
 
-
   METHOD zif_logger_display_profile~set_value.
-
     FIELD-SYMBOLS <value> TYPE any.
     ASSIGN COMPONENT i_fld OF STRUCTURE display_profile TO <value>.
     IF sy-subrc = 0.
@@ -187,4 +168,5 @@ CLASS ZCL_LOGGER_DISPLAY_PROFILE IMPLEMENTATION.
     ENDIF.
 
   ENDMETHOD.
+
 ENDCLASS.

--- a/src/zcl_logger_factory.clas.abap
+++ b/src/zcl_logger_factory.clas.abap
@@ -80,7 +80,7 @@ CLASS zcl_logger_factory IMPLEMENTATION.
       lo_log->sec_connect_commit = abap_true.
     ENDIF.
 
-  " Set deletion date and set if log can be deleted before deletion date is reached.
+    " Set deletion date and set if log can be deleted before deletion date is reached.
     lo_log->header-aldate_del = lo_log->settings->get_expiry_date( ).
     lo_log->header-del_before = lo_log->settings->get_must_be_kept_until_expiry( ).
 

--- a/src/zcl_logger_factory.clas.abap
+++ b/src/zcl_logger_factory.clas.abap
@@ -1,7 +1,7 @@
 CLASS zcl_logger_factory DEFINITION
   PUBLIC
   FINAL
-  CREATE PRIVATE .
+  CREATE PRIVATE.
 
   PUBLIC SECTION.
 
@@ -14,7 +14,7 @@ CLASS zcl_logger_factory DEFINITION
         context      TYPE simple OPTIONAL
         settings     TYPE REF TO zif_logger_settings OPTIONAL
       RETURNING
-        VALUE(r_log) TYPE REF TO zif_logger .
+        VALUE(r_log) TYPE REF TO zif_logger.
 
     "! Reopens an already existing log.
     CLASS-METHODS open_log
@@ -25,7 +25,7 @@ CLASS zcl_logger_factory DEFINITION
         create_if_does_not_exist TYPE abap_bool DEFAULT abap_false
         settings                 TYPE REF TO zif_logger_settings OPTIONAL
       RETURNING
-        VALUE(r_log)             TYPE REF TO zif_logger .
+        VALUE(r_log)             TYPE REF TO zif_logger.
 
     "! Creates a settings object which can be modified. It can be pass on
     "! the creation of the logger to change its behavior.
@@ -35,7 +35,7 @@ CLASS zcl_logger_factory DEFINITION
 
     CLASS-METHODS create_collection
       RETURNING
-        VALUE(r_collection) TYPE REF TO zif_logger_collection .
+        VALUE(r_collection) TYPE REF TO zif_logger_collection.
 
     CLASS-METHODS create_display_profile
       IMPORTING
@@ -51,15 +51,12 @@ CLASS zcl_logger_factory DEFINITION
 ENDCLASS.
 
 
-
 CLASS zcl_logger_factory IMPLEMENTATION.
 
-
   METHOD create_log.
-
-    DATA: lo_log TYPE REF TO zcl_logger.
     FIELD-SYMBOLS <context_val> TYPE c.
 
+    DATA lo_log TYPE REF TO zcl_logger.
     CREATE OBJECT lo_log.
     lo_log->header-object    = object.
     lo_log->header-subobject = subobject.
@@ -71,20 +68,19 @@ CLASS zcl_logger_factory IMPLEMENTATION.
       CREATE OBJECT lo_log->settings TYPE zcl_logger_settings.
     ENDIF.
 
-* Special case: Logger can work without object - but then
-* the data cannot be written to the database.
+    " Special case: Logger can work without object - but then the data cannot be written to the database.
     IF object IS INITIAL.
       lo_log->settings->set_autosave( abap_false ).
     ENDIF.
 
-* Use secondary database connection to write data to database even if
-* main program does a rollback (e. g. during a dump).
+    " Use secondary database connection to write data to database even if
+    " main program does a rollback (e. g. during a dump).
     IF lo_log->settings->get_usage_of_secondary_db_conn( ) = abap_true.
       lo_log->sec_connection     = abap_true.
       lo_log->sec_connect_commit = abap_true.
     ENDIF.
 
-* Set deletion date and set if log can be deleted before deletion date is reached.
+  " Set deletion date and set if log can be deleted before deletion date is reached.
     lo_log->header-aldate_del = lo_log->settings->get_expiry_date( ).
     lo_log->header-del_before = lo_log->settings->get_must_be_kept_until_expiry( ).
 
@@ -101,8 +97,8 @@ CLASS zcl_logger_factory IMPLEMENTATION.
       IMPORTING
         e_log_handle = lo_log->handle.
 
-* BAL_LOG_CREATE will fill in some additional header data.
-* This FM updates our instance attribute to reflect that.
+    " BAL_LOG_CREATE will fill in some additional header data.
+    " This FM updates our instance attribute to reflect that.
     CALL FUNCTION 'BAL_LOG_HDR_READ'
       EXPORTING
         i_log_handle = lo_log->handle
@@ -110,26 +106,19 @@ CLASS zcl_logger_factory IMPLEMENTATION.
         e_s_log      = lo_log->header.
 
     r_log = lo_log.
-
   ENDMETHOD.
-
 
   METHOD create_settings.
-
     CREATE OBJECT r_settings TYPE zcl_logger_settings.
-
   ENDMETHOD.
 
-
   METHOD open_log.
-
     DATA: filter             TYPE bal_s_lfil,
           l_object           TYPE balobj_d,
           l_subobject        TYPE balsubobj,
           extnumber          TYPE balnrext,
           found_headers      TYPE balhdr_t,
           most_recent_header TYPE balhdr.
-    DATA: lo_log             TYPE REF TO zcl_logger.
 
     l_object    = object.
     l_subobject = subobject.
@@ -160,13 +149,13 @@ CLASS zcl_logger_factory IMPLEMENTATION.
       RETURN.
     ENDIF.
 
-* Delete all but the last row.  Keep the found_headers table this way
-* so we can pass it to BAL_DB_LOAD.
+    " Delete all but the last row.  Keep the found_headers table this way so we can pass it to BAL_DB_LOAD.
     IF lines( found_headers ) > 1.
       DELETE found_headers TO ( lines( found_headers ) - 1 ).
     ENDIF.
     READ TABLE found_headers INDEX 1 INTO most_recent_header.
 
+    DATA lo_log TYPE REF TO zcl_logger.
     CREATE OBJECT lo_log.
     lo_log->db_number = most_recent_header-lognumber.
     lo_log->handle    = most_recent_header-log_handle.
@@ -188,7 +177,6 @@ CLASS zcl_logger_factory IMPLEMENTATION.
         e_s_log      = lo_log->header.
 
     r_log = lo_log.
-
   ENDMETHOD.
 
   METHOD create_collection.
@@ -198,11 +186,11 @@ CLASS zcl_logger_factory IMPLEMENTATION.
   METHOD create_display_profile.
     CREATE OBJECT r_display_profile TYPE zcl_logger_display_profile.
     r_display_profile->set(
-     i_detlevel    = i_detlevel
-     i_no_tree     = i_no_tree
-     i_popup       = i_popup
-     i_single_log  = i_single_log
-     i_standard    = i_standard ).
+      i_detlevel    = i_detlevel
+      i_no_tree     = i_no_tree
+      i_popup       = i_popup
+      i_single_log  = i_single_log
+      i_standard    = i_standard ).
   ENDMETHOD.
 
 ENDCLASS.

--- a/src/zcl_logger_settings.clas.abap
+++ b/src/zcl_logger_settings.clas.abap
@@ -10,7 +10,7 @@ CLASS zcl_logger_settings DEFINITION
   PROTECTED SECTION.
   PRIVATE SECTION.
     DATA auto_save                 TYPE abap_bool.
-    DATA expiry_date               TYPE aldate_del .
+    DATA expiry_date               TYPE aldate_del.
     DATA must_be_kept_until_expiry TYPE del_before.
     DATA max_exception_drill_down  TYPE i.
     DATA use_2nd_db_connection     TYPE flag.

--- a/src/zcl_logger_settings.clas.testclasses.abap
+++ b/src/zcl_logger_settings.clas.testclasses.abap
@@ -20,7 +20,7 @@ ENDCLASS.
 CLASS lcl_logger_settings_should IMPLEMENTATION.
 
   METHOD setup.
-    cut = NEW zcl_logger_settings( ).
+    CREATE OBJECT cut.
   ENDMETHOD.
 
   METHOD have_correct_defaults.

--- a/src/zcl_logger_settings.clas.testclasses.abap
+++ b/src/zcl_logger_settings.clas.testclasses.abap
@@ -20,124 +20,90 @@ ENDCLASS.
 CLASS lcl_logger_settings_should IMPLEMENTATION.
 
   METHOD setup.
-    CREATE OBJECT cut.
+    cut = NEW zcl_logger_settings( ).
   ENDMETHOD.
 
   METHOD have_correct_defaults.
-    cl_aunit_assert=>assert_equals(
-      EXPORTING
-        exp     = abap_true
-        act     = cut->zif_logger_settings~get_autosave( )
-        msg     = |Auto save should be on by default|
-    ).
-    cl_aunit_assert=>assert_equals(
-      EXPORTING
-        exp     = abap_true
-        act     = cut->zif_logger_settings~get_usage_of_secondary_db_conn( )
-        msg     = |2nd database connection should be used by default|
-    ).
-    cl_aunit_assert=>assert_equals(
-      EXPORTING
-        exp     = abap_false
-        act     = cut->zif_logger_settings~get_must_be_kept_until_expiry( )
-        msg     = |Log should be deletable before expiry date is reached by default|
-    ).
-    cl_aunit_assert=>assert_initial(
-      EXPORTING
-        act     = cut->zif_logger_settings~get_expiry_date( )
-        msg     = |No expiry date set by default|
-    ).
-    cl_aunit_assert=>assert_equals(
-      EXPORTING
-        exp     = 10
-        act     = cut->zif_logger_settings~get_max_exception_drill_down( )
-        msg     = |Max exception drill down should be 10 by default|
-    ).
+    cl_abap_unit_assert=>assert_true(
+      act     = cut->zif_logger_settings~get_autosave( )
+      msg     = |Auto save should be on by default| ).
+    cl_abap_unit_assert=>assert_true(
+      act     = cut->zif_logger_settings~get_usage_of_secondary_db_conn( )
+      msg     = |2nd database connection should be used by default| ).
+    cl_abap_unit_assert=>assert_false(
+      act     = cut->zif_logger_settings~get_must_be_kept_until_expiry( )
+      msg     = |Log should be deletable before expiry date is reached by default| ).
+    cl_abap_unit_assert=>assert_initial(
+      act     = cut->zif_logger_settings~get_expiry_date( )
+      msg     = |No expiry date set by default| ).
+    cl_abap_unit_assert=>assert_equals(
+      exp     = 10
+      act     = cut->zif_logger_settings~get_max_exception_drill_down( )
+      msg     = |Max exception drill down should be 10 by default| ).
   ENDMETHOD.
 
   METHOD set_autosave.
     cut->zif_logger_settings~set_autosave( abap_false ).
-    cl_aunit_assert=>assert_equals(
-      EXPORTING
-        exp     = abap_false
-        act     = cut->zif_logger_settings~get_autosave( )
-        msg     = |Auto save was not deactivated correctly|
-    ).
+    cl_abap_unit_assert=>assert_false(
+      act     = cut->zif_logger_settings~get_autosave( )
+      msg     = |Auto save was not deactivated correctly| ).
   ENDMETHOD.
 
   METHOD set_expiry_date.
     cut->zif_logger_settings~set_expiry_date( '20161030' ).
-    cl_aunit_assert=>assert_equals(
-      EXPORTING
-        exp     = '20161030'
-        act     = cut->zif_logger_settings~get_expiry_date( )
-        msg     = |Expiry date was not set correctly|
-    ).
+    cl_abap_unit_assert=>assert_equals(
+      exp     = '20161030'
+      act     = cut->zif_logger_settings~get_expiry_date( )
+      msg     = |Expiry date was not set correctly| ).
   ENDMETHOD.
 
   METHOD set_expiry_in_days.
     cut->zif_logger_settings~set_expiry_in_days( -1 ).
-    cl_aunit_assert=>assert_initial(
-      EXPORTING
-        act     = cut->zif_logger_settings~get_expiry_date( )
-        msg     = |Expiry in days should remain default when setting incorrect values.|
-    ).
+    cl_abap_unit_assert=>assert_initial(
+      act     = cut->zif_logger_settings~get_expiry_date( )
+      msg     = |Expiry in days should remain default when setting incorrect values.| ).
 
     cut->zif_logger_settings~set_expiry_in_days( 10 ).
 
     DATA lv_exp TYPE d.
     lv_exp = sy-datum + 10.
 
-    cl_aunit_assert=>assert_equals(
-      EXPORTING
-        exp     = lv_exp
-        act     = cut->zif_logger_settings~get_expiry_date( )
-        msg     = |Expiry in days was not set correctly.|
-    ).
+    cl_abap_unit_assert=>assert_equals(
+      exp     = lv_exp
+      act     = cut->zif_logger_settings~get_expiry_date( )
+      msg     = |Expiry in days was not set correctly.| ).
   ENDMETHOD.
 
   METHOD set_flag_to_keep_until_expiry.
     cut->zif_logger_settings~set_must_be_kept_until_expiry( abap_true ).
-    cl_aunit_assert=>assert_equals(
-      EXPORTING
-        exp     = abap_true
-        act     = cut->zif_logger_settings~get_must_be_kept_until_expiry( )
-        msg     = |Setter for keeping log until expiry is not working correctly.|
-    ).
+    cl_abap_unit_assert=>assert_true(
+      act     = cut->zif_logger_settings~get_must_be_kept_until_expiry( )
+      msg     = |Setter for keeping log until expiry is not working correctly.| ).
   ENDMETHOD.
 
   METHOD set_usage_of_2nd_db_connection.
     cut->zif_logger_settings~set_usage_of_secondary_db_conn( abap_false ).
-    cl_aunit_assert=>assert_equals(
-      EXPORTING
-        exp     = abap_false
-        act     = cut->zif_logger_settings~get_usage_of_secondary_db_conn( )
-        msg     = |Setter for using 2nd db connection is not working correctly.|
-    ).
+    cl_abap_unit_assert=>assert_false(
+      act     = cut->zif_logger_settings~get_usage_of_secondary_db_conn( )
+      msg     = |Setter for using 2nd db connection is not working correctly.| ).
   ENDMETHOD.
 
   METHOD set_max_drilldown_level.
     cut->zif_logger_settings~set_max_exception_drill_down( 20 ).
-    cl_aunit_assert=>assert_equals(
-      EXPORTING
-        exp     = 20
-        act     = cut->zif_logger_settings~get_max_exception_drill_down( )
-        msg     = |Setter for max drilldown level is not working correctly.|
-    ).
+    cl_abap_unit_assert=>assert_equals(
+      exp     = 20
+      act     = cut->zif_logger_settings~get_max_exception_drill_down( )
+      msg     = |Setter for max drilldown level is not working correctly.| ).
     cut->zif_logger_settings~set_max_exception_drill_down( -1 ).
-    cl_aunit_assert=>assert_equals(
-      EXPORTING
-        exp     = 20
-        act     = cut->zif_logger_settings~get_max_exception_drill_down( )
-        msg     = |Max exception drill down level should not change if value is incorrect.|
-    ).
+    cl_abap_unit_assert=>assert_equals(
+      exp     = 20
+      act     = cut->zif_logger_settings~get_max_exception_drill_down( )
+      msg     = |Max exception drill down level should not change if value is incorrect.| ).
     cut->zif_logger_settings~set_max_exception_drill_down( 0 ).
-    cl_aunit_assert=>assert_equals(
-      EXPORTING
-        exp     = 0
-        act     = cut->zif_logger_settings~get_max_exception_drill_down( )
-        msg     = |Max exception drill down should be deactivatable.|
-    ).
+    cl_abap_unit_assert=>assert_equals(
+      exp     = 0
+      act     = cut->zif_logger_settings~get_max_exception_drill_down( )
+      msg     = |Max exception drill down should be deactivatable.| ).
   ENDMETHOD.
 
 ENDCLASS.

--- a/src/zcx_logger.clas.abap
+++ b/src/zcx_logger.clas.abap
@@ -1,36 +1,35 @@
-class ZCX_LOGGER definition
-  public
-  inheriting from CX_NO_CHECK
-  create public .
+CLASS zcx_logger DEFINITION
+  PUBLIC
+  INHERITING FROM cx_no_check
+  CREATE PUBLIC.
 
-public section.
+  PUBLIC SECTION.
 
-  constants ZCX_LOGGER type SOTR_CONC value 'B9D98DB24EAF1EDD8ED3241224D60A6A' ##NO_TEXT.
-  data INFO type STRING .
+    CONSTANTS zcx_logger TYPE sotr_conc VALUE 'B9D98DB24EAF1EDD8ED3241224D60A6A' ##NO_TEXT.
+    DATA info TYPE string .
 
-  methods CONSTRUCTOR
-    importing
-      !TEXTID like TEXTID optional
-      !PREVIOUS like PREVIOUS optional
-      !INFO type STRING optional .
-protected section.
-private section.
+    METHODS constructor
+    IMPORTING
+      !textid LIKE textid OPTIONAL
+      !previous LIKE previous OPTIONAL
+      !info TYPE string OPTIONAL.
+  PROTECTED SECTION.
+  PRIVATE SECTION.
 ENDCLASS.
 
 
 
-CLASS ZCX_LOGGER IMPLEMENTATION.
+CLASS zcx_logger IMPLEMENTATION.
 
+  METHOD constructor.
+    CALL METHOD super->constructor
+      EXPORTING
+      textid = textid
+      previous = previous.
+    IF textid IS INITIAL.
+      me->textid = zcx_logger.
+    ENDIF.
+    me->info = info.
+  ENDMETHOD.
 
-  method CONSTRUCTOR.
-CALL METHOD SUPER->CONSTRUCTOR
-EXPORTING
-TEXTID = TEXTID
-PREVIOUS = PREVIOUS
-.
- IF textid IS INITIAL.
-   me->textid = ZCX_LOGGER .
- ENDIF.
-me->INFO = INFO .
-  endmethod.
 ENDCLASS.

--- a/src/zcx_logger.clas.abap
+++ b/src/zcx_logger.clas.abap
@@ -6,13 +6,13 @@ CLASS zcx_logger DEFINITION
   PUBLIC SECTION.
 
     CONSTANTS zcx_logger TYPE sotr_conc VALUE 'B9D98DB24EAF1EDD8ED3241224D60A6A' ##NO_TEXT.
-    DATA info TYPE string .
+    DATA info TYPE string.
 
     METHODS constructor
     IMPORTING
-      !textid LIKE textid OPTIONAL
-      !previous LIKE previous OPTIONAL
-      !info TYPE string OPTIONAL.
+      textid LIKE textid OPTIONAL
+      previous LIKE previous OPTIONAL
+      info TYPE string OPTIONAL.
   PROTECTED SECTION.
   PRIVATE SECTION.
 ENDCLASS.
@@ -24,8 +24,8 @@ CLASS zcx_logger IMPLEMENTATION.
   METHOD constructor.
     CALL METHOD super->constructor
       EXPORTING
-      textid = textid
-      previous = previous.
+        textid = textid
+        previous = previous.
     IF textid IS INITIAL.
       me->textid = zcx_logger.
     ENDIF.

--- a/src/zcx_logger_display_profile.clas.abap
+++ b/src/zcx_logger_display_profile.clas.abap
@@ -22,9 +22,9 @@ CLASS zcx_logger_display_profile IMPLEMENTATION.
   METHOD constructor.
     CALL METHOD super->constructor
       EXPORTING
-      textid = textid
-      previous = previous
-      info = info.
+        textid = textid
+        previous = previous
+        info = info.
     IF textid IS INITIAL.
       me->textid = zcx_logger_display_profile.
     ENDIF.

--- a/src/zcx_logger_display_profile.clas.abap
+++ b/src/zcx_logger_display_profile.clas.abap
@@ -1,35 +1,33 @@
-class ZCX_LOGGER_DISPLAY_PROFILE definition
-  public
-  inheriting from ZCX_LOGGER
-  create public .
+CLASS zcx_logger_display_profile DEFINITION
+  PUBLIC
+  INHERITING FROM zcx_logger
+  CREATE PUBLIC.
 
-public section.
+  PUBLIC SECTION.
+    CONSTANTS zcx_logger_display_profile TYPE sotr_conc VALUE 'B9D98DB24EAF1EDD8ED3241224D60A6A' ##NO_TEXT.
 
-  constants ZCX_LOGGER_DISPLAY_PROFILE type SOTR_CONC value 'B9D98DB24EAF1EDD8ED3241224D60A6A' ##NO_TEXT.
-
-  methods CONSTRUCTOR
-    importing
-      !TEXTID like TEXTID optional
-      !PREVIOUS like PREVIOUS optional
-      !INFO type STRING optional .
-protected section.
-private section.
+    METHODS constructor
+    IMPORTING
+      textid LIKE textid OPTIONAL
+      previous LIKE previous OPTIONAL
+      info TYPE string OPTIONAL.
+  PROTECTED SECTION.
+  PRIVATE SECTION.
 ENDCLASS.
 
 
 
-CLASS ZCX_LOGGER_DISPLAY_PROFILE IMPLEMENTATION.
+CLASS zcx_logger_display_profile IMPLEMENTATION.
 
+  METHOD constructor.
+    CALL METHOD super->constructor
+      EXPORTING
+      textid = textid
+      previous = previous
+      info = info.
+    IF textid IS INITIAL.
+      me->textid = zcx_logger_display_profile.
+    ENDIF.
+  ENDMETHOD.
 
-  method CONSTRUCTOR.
-CALL METHOD SUPER->CONSTRUCTOR
-EXPORTING
-TEXTID = TEXTID
-PREVIOUS = PREVIOUS
-INFO = INFO
-.
- IF textid IS INITIAL.
-   me->textid = ZCX_LOGGER_DISPLAY_PROFILE .
- ENDIF.
-  endmethod.
 ENDCLASS.

--- a/src/zif_loggable_object.intf.abap
+++ b/src/zif_loggable_object.intf.abap
@@ -1,5 +1,5 @@
 INTERFACE zif_loggable_object
-  PUBLIC .
+  PUBLIC.
   TYPES:
     BEGIN OF ty_symsg,
            msgid TYPE symsgid,

--- a/src/zif_logger.intf.abap
+++ b/src/zif_logger.intf.abap
@@ -1,8 +1,8 @@
 INTERFACE zif_logger
-  PUBLIC .
-  DATA handle    TYPE balloghndl READ-ONLY .
-  DATA db_number TYPE balognr READ-ONLY .
-  DATA header    TYPE bal_s_log READ-ONLY .
+  PUBLIC.
+  DATA handle    TYPE balloghndl READ-ONLY.
+  DATA db_number TYPE balognr READ-ONLY.
+  DATA header    TYPE bal_s_log READ-ONLY.
 
   METHODS add
     IMPORTING
@@ -16,7 +16,7 @@ INTERFACE zif_logger
       importance          TYPE balprobcl OPTIONAL
         PREFERRED PARAMETER obj_to_log
     RETURNING
-      VALUE(self)         TYPE REF TO zif_logger .
+      VALUE(self)         TYPE REF TO zif_logger.
 
   METHODS a
     IMPORTING
@@ -29,7 +29,7 @@ INTERFACE zif_logger
       importance          TYPE balprobcl OPTIONAL
         PREFERRED PARAMETER obj_to_log
     RETURNING
-      VALUE(self)         TYPE REF TO zif_logger .
+      VALUE(self)         TYPE REF TO zif_logger.
 
   METHODS e
     IMPORTING
@@ -42,7 +42,7 @@ INTERFACE zif_logger
       importance          TYPE balprobcl OPTIONAL
         PREFERRED PARAMETER obj_to_log
     RETURNING
-      VALUE(self)         TYPE REF TO zif_logger .
+      VALUE(self)         TYPE REF TO zif_logger.
 
   METHODS w
     IMPORTING
@@ -55,7 +55,7 @@ INTERFACE zif_logger
       importance          TYPE balprobcl OPTIONAL
         PREFERRED PARAMETER obj_to_log
     RETURNING
-      VALUE(self)         TYPE REF TO zif_logger .
+      VALUE(self)         TYPE REF TO zif_logger.
 
   METHODS i
     IMPORTING
@@ -68,7 +68,7 @@ INTERFACE zif_logger
       importance          TYPE balprobcl OPTIONAL
         PREFERRED PARAMETER obj_to_log
     RETURNING
-      VALUE(self)         TYPE REF TO zif_logger .
+      VALUE(self)         TYPE REF TO zif_logger.
 
   METHODS s
     IMPORTING
@@ -81,23 +81,23 @@ INTERFACE zif_logger
       importance          TYPE balprobcl OPTIONAL
         PREFERRED PARAMETER obj_to_log
     RETURNING
-      VALUE(self)         TYPE REF TO zif_logger .
+      VALUE(self)         TYPE REF TO zif_logger.
 
   METHODS has_errors
     RETURNING
-      VALUE(rv_yes) TYPE abap_bool .
+      VALUE(rv_yes) TYPE abap_bool.
 
   METHODS has_warnings
     RETURNING
-      VALUE(rv_yes) TYPE abap_bool .
+      VALUE(rv_yes) TYPE abap_bool.
 
   METHODS is_empty
     RETURNING
-      VALUE(rv_yes) TYPE abap_bool .
+      VALUE(rv_yes) TYPE abap_bool.
 
   METHODS length
     RETURNING
-      VALUE(rv_length) TYPE i .
+      VALUE(rv_length) TYPE i.
 
   "! Saves the log on demand. Intended to be called at the
   "! end of the log processing so that logs can be saved depending
@@ -105,13 +105,13 @@ INTERFACE zif_logger
   "! If there are no error messages, it may not be desirable to save
   "! a log.
   "! If auto save is enabled, save will do nothing.
-  METHODS save .
+  METHODS save.
 
   METHODS export_to_table
     RETURNING
-      VALUE(rt_bapiret) TYPE bapirettab .
+      VALUE(rt_bapiret) TYPE bapirettab.
 
-  METHODS fullscreen .
+  METHODS fullscreen.
 
   METHODS popup
     IMPORTING
@@ -121,6 +121,6 @@ INTERFACE zif_logger
     IMPORTING
       description TYPE bal_s_log-extnumber
     RETURNING
-      VALUE(self) TYPE REF TO zif_logger .
+      VALUE(self) TYPE REF TO zif_logger.
 
 ENDINTERFACE.

--- a/src/zif_logger_collection.intf.abap
+++ b/src/zif_logger_collection.intf.abap
@@ -1,5 +1,5 @@
 INTERFACE zif_logger_collection
-  PUBLIC .
+  PUBLIC.
 
   METHODS add_logger
     IMPORTING

--- a/src/zif_logger_display_profile.intf.abap
+++ b/src/zif_logger_display_profile.intf.abap
@@ -1,35 +1,34 @@
 INTERFACE zif_logger_display_profile
-  PUBLIC .
-
+  PUBLIC.
 
   METHODS set
     IMPORTING
-      !i_detlevel   TYPE clike OPTIONAL
-      !i_no_tree    TYPE clike OPTIONAL
-      !i_popup      TYPE clike OPTIONAL
-      !i_single_log TYPE clike OPTIONAL
-      !i_standard   TYPE clike DEFAULT abap_true
+      i_detlevel   TYPE clike OPTIONAL
+      i_no_tree    TYPE clike OPTIONAL
+      i_popup      TYPE clike OPTIONAL
+      i_single_log TYPE clike OPTIONAL
+      i_standard   TYPE clike DEFAULT abap_true
     RETURNING
-      VALUE(r_self) TYPE REF TO zif_logger_display_profile .
+      VALUE(r_self) TYPE REF TO zif_logger_display_profile.
   METHODS get
     RETURNING
-      VALUE(r_display_profile) TYPE bal_s_prof .
+      VALUE(r_display_profile) TYPE bal_s_prof.
   METHODS set_grid
     IMPORTING
-      !i_grid_mode  TYPE clike
+      i_grid_mode  TYPE clike
     RETURNING
-      VALUE(r_self) TYPE REF TO zif_logger_display_profile .
+      VALUE(r_self) TYPE REF TO zif_logger_display_profile.
   METHODS set_value
     IMPORTING
-      !i_fld        TYPE clike
-      !i_val        TYPE any
+      i_fld        TYPE clike
+      i_val        TYPE any
     RETURNING
-      VALUE(r_self) TYPE REF TO zif_logger_display_profile .
+      VALUE(r_self) TYPE REF TO zif_logger_display_profile.
   METHODS set_context_tree
     IMPORTING
-      !i_context_structure TYPE clike
-      !i_under_log         TYPE clike DEFAULT space .
+      i_context_structure TYPE clike
+      i_under_log         TYPE clike DEFAULT space.
   METHODS set_context_message
     IMPORTING
-      !i_context_structure TYPE clike .
+      i_context_structure TYPE clike.
 ENDINTERFACE.

--- a/src/zif_logger_settings.intf.abap
+++ b/src/zif_logger_settings.intf.abap
@@ -1,4 +1,4 @@
-INTERFACE zif_logger_settings PUBLIC .
+INTERFACE zif_logger_settings PUBLIC.
 
   "! Is the log automatically saved when adding messages?
   "! See setter for more details.


### PR DESCRIPTION
Various clean code fixes and cleanup, including new abapLint rules enabled.

@AlexandreHT do you plan to keep this compatible with 7.02 for the time being? There could be quite a bit more cleaned up if it were upgraded.