### PR TITLE
Fix for bug #110 - "LV_CONTEXT" Type changed from simple to any

### DIFF
--- a/src/zcl_logger.clas.abap
+++ b/src/zcl_logger.clas.abap
@@ -39,7 +39,7 @@ CLASS zcl_logger DEFINITION
         !object         TYPE csequence OPTIONAL
         !subobject      TYPE csequence OPTIONAL
         !desc           TYPE csequence OPTIONAL
-        !context        TYPE simple OPTIONAL
+        !context        TYPE any OPTIONAL
         !auto_save      TYPE abap_bool OPTIONAL
         !second_db_conn TYPE abap_bool DEFAULT abap_true
       RETURNING
@@ -95,7 +95,7 @@ CLASS zcl_logger DEFINITION
       add_structure
         IMPORTING
           obj_to_log    TYPE any OPTIONAL
-          context       TYPE simple OPTIONAL
+          context       TYPE any OPTIONAL
           callback_form TYPE csequence OPTIONAL
           callback_prog TYPE csequence OPTIONAL
           callback_fm   TYPE csequence OPTIONAL

--- a/src/zcl_logger_factory.clas.abap
+++ b/src/zcl_logger_factory.clas.abap
@@ -11,7 +11,7 @@ CLASS zcl_logger_factory DEFINITION
         object       TYPE csequence OPTIONAL
         subobject    TYPE csequence OPTIONAL
         desc         TYPE csequence OPTIONAL
-        context      TYPE simple OPTIONAL
+        context      TYPE any OPTIONAL
         settings     TYPE REF TO zif_logger_settings OPTIONAL
       RETURNING
         VALUE(r_log) TYPE REF TO zif_logger .

--- a/src/zif_logger.intf.abap
+++ b/src/zif_logger.intf.abap
@@ -21,7 +21,7 @@ INTERFACE zif_logger
   METHODS a
     IMPORTING
       obj_to_log          TYPE any OPTIONAL
-      context             TYPE simple OPTIONAL
+      context             TYPE any OPTIONAL
       callback_form       TYPE csequence OPTIONAL
       callback_prog       TYPE csequence OPTIONAL
       callback_fm         TYPE csequence OPTIONAL
@@ -34,7 +34,7 @@ INTERFACE zif_logger
   METHODS e
     IMPORTING
       obj_to_log          TYPE any OPTIONAL
-      context             TYPE simple OPTIONAL
+      context             TYPE any OPTIONAL
       callback_form       TYPE csequence OPTIONAL
       callback_prog       TYPE csequence OPTIONAL
       callback_fm         TYPE csequence OPTIONAL
@@ -47,7 +47,7 @@ INTERFACE zif_logger
   METHODS w
     IMPORTING
       obj_to_log          TYPE any OPTIONAL
-      context             TYPE simple OPTIONAL
+      context             TYPE any OPTIONAL
       callback_form       TYPE csequence OPTIONAL
       callback_prog       TYPE csequence OPTIONAL
       callback_fm         TYPE csequence OPTIONAL
@@ -60,7 +60,7 @@ INTERFACE zif_logger
   METHODS i
     IMPORTING
       obj_to_log          TYPE any OPTIONAL
-      context             TYPE simple OPTIONAL
+      context             TYPE any OPTIONAL
       callback_form       TYPE csequence OPTIONAL
       callback_prog       TYPE csequence OPTIONAL
       callback_fm         TYPE csequence OPTIONAL
@@ -73,7 +73,7 @@ INTERFACE zif_logger
   METHODS s
     IMPORTING
       obj_to_log          TYPE any OPTIONAL
-      context             TYPE simple OPTIONAL
+      context             TYPE any OPTIONAL
       callback_form       TYPE csequence OPTIONAL
       callback_prog       TYPE csequence OPTIONAL
       callback_fm         TYPE csequence OPTIONAL


### PR DESCRIPTION
Fix for bug [#110](https://github.com/ABAP-Logger/ABAP-Logger/issues/110) - "LV_CONTEXT" Type changed from simple to any in the following.

CLASS zcl_logger
    method add_structure
    CLASS-METHODS new

CLASS zcl_logger_factory 
    CLASS-METHODS create_log

INTERFACE zif_logger
	METHODS a e w i s 