### PR TITLE
Rename methods for displaying log

### DIFF
--- a/src/zif_logger.intf.abap
+++ b/src/zif_logger.intf.abap
@@ -111,9 +111,9 @@ INTERFACE zif_logger
     RETURNING
       VALUE(rt_bapiret) TYPE bapirettab.
 
-  METHODS fullscreen.
+  METHODS display_fullscreen.
 
-  METHODS popup
+  METHODS display_as_popup
     IMPORTING
       profile TYPE bal_s_prof OPTIONAL.
 


### PR DESCRIPTION
Renames `fullscreen` to `display_fullscreen` and `popup` to `display_as_popup`. 
Adds aliases for downward compatibility.

Ref https://github.com/ABAP-Logger/ABAP-Logger/pull/135#issuecomment-1738768179

PS: Reordering and spacing due to SE80 