### PR TITLE
Fix logging of structures with unnamed components

### DIFF
--- a/src/zcl_logger.clas.abap
+++ b/src/zcl_logger.clas.abap
@@ -201,7 +201,7 @@ CLASS zcl_logger IMPLEMENTATION.
       ASSIGN COMPONENT component_name OF STRUCTURE obj_to_log TO <component>.
       IF sy-subrc <> 0.
         " It might be an unnamed component like .INCLUDE
-        component_name = |#{ sy-tabix }|.
+        component_name = |Include { sy-tabix }|.
         ASSIGN COMPONENT sy-tabix OF STRUCTURE obj_to_log TO <component>.
       ENDIF.
       IF sy-subrc = 0.


### PR DESCRIPTION
Fixes logging of fields in .INCLUDE structures that do not have a name.

Closes #21