### PR TITLE
Adding exception together with context. Fix for #161.

### DIFF
--- a/src/zcl_logger.clas.abap
+++ b/src/zcl_logger.clas.abap
@@ -1098,9 +1098,9 @@ CLASS zcl_logger IMPLEMENTATION.
 * get text for textid
       CONCATENATE '''' i_s_exc-exception->textid '''' INTO l_class_id.
       SELECT cmpname INTO l_cmpname
-        FROM seocompodf UP TO 1 ROWS
-        WHERE clsname = l_exception_description->class_name
-        AND attvalue  = l_class_id.
+          FROM seocompodf UP TO 1 ROWS
+          WHERE clsname = l_exception_description->class_name
+          AND attvalue  = l_class_id.
       ENDSELECT.
 *   fill basic data of message
 *   message variables are used to store:

--- a/src/zcl_logger.clas.abap
+++ b/src/zcl_logger.clas.abap
@@ -1080,26 +1080,18 @@ CLASS zcl_logger IMPLEMENTATION.
     END-OF-DEFINITION.
 
 * get the parameter for text switching
-    CALL METHOD cl_message_helper=>get_text_params
-      EXPORTING
-        obj    = i_s_exc-exception
-      IMPORTING
-        params = l_substitution_table.
+    cl_message_helper=>get_text_params( EXPORTING obj    = i_s_exc-exception
+                                        IMPORTING params = l_substitution_table ).
 
 * exception -> type OTR-message or T100-message?
-    CALL METHOD cl_message_helper=>check_msg_kind
-      EXPORTING
-        msg     = i_s_exc-exception
-      IMPORTING
-        t100key = l_t100key
-        textid  = l_textid.
+    cl_message_helper=>check_msg_kind( EXPORTING msg     = i_s_exc-exception
+                                       IMPORTING t100key = l_t100key
+                                                 textid  = l_textid ).
 
     IF l_textid IS NOT INITIAL.
 
 * get name of exception class
-      CREATE OBJECT l_exception_description
-        EXPORTING
-          the_subject = i_s_exc-exception.
+      l_exception_description = new #( the_subject = i_s_exc-exception ).
 
 * get text for textid
       CONCATENATE '''' i_s_exc-exception->textid '''' INTO l_class_id.

--- a/src/zcl_logger.clas.abap
+++ b/src/zcl_logger.clas.abap
@@ -378,7 +378,6 @@ CLASS zcl_logger IMPLEMENTATION.
 
   METHOD get_struct_kind.
     DATA: ddic_header type x030l,
-          structure_name type tabname,
           msg_struct_kind   TYPE REF TO cl_abap_structdescr,
           components        TYPE abap_compdescr_tab,
           component         LIKE LINE OF components,

--- a/src/zcl_logger.clas.abap
+++ b/src/zcl_logger.clas.abap
@@ -377,7 +377,7 @@ CLASS zcl_logger IMPLEMENTATION.
 
 
   METHOD get_struct_kind.
-    DATA: ddic_header type x030l,
+    DATA: ddic_header       type x030l,
           msg_struct_kind   TYPE REF TO cl_abap_structdescr,
           components        TYPE abap_compdescr_tab,
           component         LIKE LINE OF components,
@@ -392,7 +392,7 @@ CLASS zcl_logger IMPLEMENTATION.
     IF msg_type->type_kind = cl_abap_typedescr=>typekind_struct1
         OR msg_type->type_kind = cl_abap_typedescr=>typekind_struct2.
 
-      if msg_type->is_ddic_type( ).
+      if msg_type->is_ddic_type( ) = abap_true.
         ddic_header = msg_type->get_ddic_header( ).
         if ddic_header-tabname = 'BAL_S_MSG'.
           result = c_struct_kind-application_log.
@@ -1091,7 +1091,9 @@ CLASS zcl_logger IMPLEMENTATION.
     IF l_textid IS NOT INITIAL.
 
 * get name of exception class
-      l_exception_description = new #( the_subject = i_s_exc-exception ).
+      CREATE OBJECT l_exception_description
+        EXPORTING
+          the_subject = i_s_exc-exception.
 
 * get text for textid
       CONCATENATE '''' i_s_exc-exception->textid '''' INTO l_class_id.

--- a/src/zcl_logger.clas.abap
+++ b/src/zcl_logger.clas.abap
@@ -73,7 +73,7 @@ CLASS zcl_logger DEFINITION
         bapi_alm           TYPE i VALUE 5,
         bapi_meth          TYPE i VALUE 6,
         bapi_status_result TYPE i VALUE 7,
-        application_log    type i VALUE 8,
+        application_log    TYPE i VALUE 8,
       END OF c_struct_kind.
 
     DATA sec_connection     TYPE abap_bool.
@@ -149,12 +149,12 @@ CLASS zcl_logger DEFINITION
         VALUE(detailed_msg) TYPE bal_s_msg.
     METHODS add_bapi_status_result
       IMPORTING
-         obj_to_log         TYPE any
+        obj_to_log          TYPE any
       RETURNING
         VALUE(detailed_msg) TYPE bal_s_msg.
     METHODS add_exception
       IMPORTING
-        i_s_exc TYPE bal_s_exc
+                i_s_exc        TYPE bal_s_exc
       RETURNING VALUE(c_s_msg) TYPE bal_s_msg.
 ENDCLASS.
 
@@ -377,7 +377,7 @@ CLASS zcl_logger IMPLEMENTATION.
 
 
   METHOD get_struct_kind.
-    DATA: ddic_header       type x030l,
+    DATA: ddic_header       TYPE x030l,
           msg_struct_kind   TYPE REF TO cl_abap_structdescr,
           components        TYPE abap_compdescr_tab,
           component         LIKE LINE OF components,
@@ -392,13 +392,13 @@ CLASS zcl_logger IMPLEMENTATION.
     IF msg_type->type_kind = cl_abap_typedescr=>typekind_struct1
         OR msg_type->type_kind = cl_abap_typedescr=>typekind_struct2.
 
-      if msg_type->is_ddic_type( ) = abap_true.
+      IF msg_type->is_ddic_type( ) = abap_true.
         ddic_header = msg_type->get_ddic_header( ).
-        if ddic_header-tabname = 'BAL_S_MSG'.
+        IF ddic_header-tabname = 'BAL_S_MSG'.
           result = c_struct_kind-application_log.
-          return.
-        endif.
-      endif.
+          RETURN.
+        ENDIF.
+      ENDIF.
 
       msg_struct_kind ?= msg_type.
       components = msg_struct_kind->components.
@@ -636,7 +636,7 @@ CLASS zcl_logger IMPLEMENTATION.
       detailed_msg = add_bapi_meth_msg( obj_to_log ).
     ELSEIF struct_kind = c_struct_kind-bapi_status_result.
       detailed_msg = add_bapi_status_result( obj_to_log ).
-    elseif struct_kind = c_struct_kind-application_log.
+    ELSEIF struct_kind = c_struct_kind-application_log.
       detailed_msg = obj_to_log.
     ELSEIF msg_type->type_kind = cl_abap_typedescr=>typekind_oref.
       TRY.
@@ -745,9 +745,9 @@ CLASS zcl_logger IMPLEMENTATION.
       ENDLOOP.
     ELSEIF detailed_msg IS NOT INITIAL.
       detailed_msg-context   = formatted_context.
-      if detailed_msg-params is INITIAL.
+      IF detailed_msg-params IS INITIAL.
         detailed_msg-params = formatted_params.
-      endif.
+      ENDIF.
       detailed_msg-probclass = importance.
       detailed_msg-detlevel  = detlevel.
       IF type IS NOT INITIAL.
@@ -1061,7 +1061,7 @@ CLASS zcl_logger IMPLEMENTATION.
           l_t100key               TYPE scx_t100key,
           l_textid                TYPE sotr_conc,
           l_substitution_table    TYPE sotr_params,
-          l_param    TYPE sotr_param-param.
+          l_param                 TYPE sotr_param-param.
 
     FIELD-SYMBOLS:
            <l_substitution>       TYPE sotr_param.
@@ -1097,9 +1097,8 @@ CLASS zcl_logger IMPLEMENTATION.
 
 * get text for textid
       CONCATENATE '''' i_s_exc-exception->textid '''' INTO l_class_id.
-      SELECT cmpname
-      FROM seocompodf UP TO 1 rows
-      INTO l_cmpname
+      SELECT cmpname INTO l_cmpname
+        FROM seocompodf UP TO 1 ROWS
         WHERE clsname = l_exception_description->class_name
         AND attvalue  = l_class_id.
       ENDSELECT.

--- a/src/zcl_logger.clas.abap
+++ b/src/zcl_logger.clas.abap
@@ -731,12 +731,8 @@ CLASS zcl_logger IMPLEMENTATION.
                        formatted_params = formatted_params ).
       ENDLOOP.
     ELSEIF detailed_msg IS NOT INITIAL.
-      IF formatted_context IS NOT INITIAL.
-        detailed_msg-context   = formatted_context.
-      ENDIF.
-      IF formatted_params IS NOT INITIAL.
-        detailed_msg-params = formatted_params.
-      ENDIF.
+      detailed_msg-context   = formatted_context.
+      detailed_msg-params    = formatted_params.
       detailed_msg-probclass = importance.
       detailed_msg-detlevel  = detlevel.
       IF type IS NOT INITIAL.
@@ -1066,6 +1062,7 @@ CLASS zcl_logger IMPLEMENTATION.
                                                  textid  = l_textid ).
 
     IF l_textid IS NOT INITIAL.
+      "If it is a OTR-message
       CALL FUNCTION 'BAL_LOG_EXCEPTION_ADD'
         EXPORTING
           i_log_handle = me->handle

--- a/src/zcl_logger.clas.abap
+++ b/src/zcl_logger.clas.abap
@@ -393,8 +393,6 @@ CLASS zcl_logger IMPLEMENTATION.
     IF msg_type->type_kind = cl_abap_typedescr=>typekind_struct1
         OR msg_type->type_kind = cl_abap_typedescr=>typekind_struct2.
 
-      msg_struct_kind ?= msg_type.
-
       if msg_type->is_ddic_type( ).
         ddic_header = msg_type->get_ddic_header( ).
         if ddic_header-tabname = 'BAL_S_MSG'.
@@ -403,6 +401,7 @@ CLASS zcl_logger IMPLEMENTATION.
         endif.
       endif.
 
+      msg_struct_kind ?= msg_type.
       components = msg_struct_kind->components.
 
       " Count number of fields expected for each supported type of message structure

--- a/src/zcl_logger.clas.abap
+++ b/src/zcl_logger.clas.abap
@@ -154,10 +154,10 @@ CLASS zcl_logger DEFINITION
     METHODS add_exception
       IMPORTING
         exception_data    TYPE bal_s_exc
-        formatted_context type bal_s_cont
-        formatted_params  type bal_s_parm.
+        formatted_context TYPE bal_s_cont
+        formatted_params  TYPE bal_s_parm.
 
-        .
+    .
 ENDCLASS.
 
 
@@ -379,16 +379,16 @@ CLASS zcl_logger IMPLEMENTATION.
 
 
   METHOD get_struct_kind.
-    DATA: msg_struct_kind       TYPE REF TO cl_abap_structdescr,
-          components            TYPE abap_compdescr_tab,
-          component             LIKE LINE OF components,
-          syst_count            TYPE i,
-          bapi_count            TYPE i,
-          bdc_count             TYPE i,
-          sprot_count           TYPE i,
-          bapi_alm_count        TYPE i,
-          bapi_meth_count       TYPE i,
-          bapi_status_count     TYPE i.
+    DATA: msg_struct_kind   TYPE REF TO cl_abap_structdescr,
+          components        TYPE abap_compdescr_tab,
+          component         LIKE LINE OF components,
+          syst_count        TYPE i,
+          bapi_count        TYPE i,
+          bdc_count         TYPE i,
+          sprot_count       TYPE i,
+          bapi_alm_count    TYPE i,
+          bapi_meth_count   TYPE i,
+          bapi_status_count TYPE i.
 
     IF msg_type->type_kind = cl_abap_typedescr=>typekind_struct1
         OR msg_type->type_kind = cl_abap_typedescr=>typekind_struct2.
@@ -1038,11 +1038,11 @@ CLASS zcl_logger IMPLEMENTATION.
 
   METHOD add_exception.
 
-    DATA: detailed_msg                  TYPE bal_s_msg,
-          l_t100key               TYPE scx_t100key,
-          l_textid                TYPE sotr_conc,
-          l_substitution_table    TYPE sotr_params,
-          l_param                 TYPE sotr_param-param.
+    DATA: detailed_msg         TYPE bal_s_msg,
+          l_t100key            TYPE scx_t100key,
+          l_textid             TYPE sotr_conc,
+          l_substitution_table TYPE sotr_params,
+          l_param              TYPE sotr_param-param.
 
     FIELD-SYMBOLS:
            <l_substitution>       TYPE sotr_param.
@@ -1054,7 +1054,7 @@ CLASS zcl_logger IMPLEMENTATION.
                                         WITH KEY param =  l_param.
         IF sy-subrc IS INITIAL.
           IF NOT <l_substitution>-value IS INITIAL.
-            detailed_msg-msgv&1 =  <l_substitution>-value.        "#EC *
+            detailed_msg-msgv&1 =  <l_substitution>-value.  "#EC *
           ENDIF.
         ENDIF.
       ENDIF.
@@ -1093,10 +1093,10 @@ CLASS zcl_logger IMPLEMENTATION.
     detailed_msg-context   = formatted_context.
     detailed_msg-params    = formatted_params.
 
-      CALL FUNCTION 'BAL_LOG_MSG_ADD'
-        EXPORTING
-          i_log_handle = me->handle
-          i_s_msg      = detailed_msg.
+    CALL FUNCTION 'BAL_LOG_MSG_ADD'
+      EXPORTING
+        i_log_handle = me->handle
+        i_s_msg      = detailed_msg.
 
   ENDMETHOD.
 

--- a/src/zcl_logger.clas.abap
+++ b/src/zcl_logger.clas.abap
@@ -73,6 +73,7 @@ CLASS zcl_logger DEFINITION
         bapi_alm           TYPE i VALUE 5,
         bapi_meth          TYPE i VALUE 6,
         bapi_status_result TYPE i VALUE 7,
+        application_log    type i VALUE 8,
       END OF c_struct_kind.
 
     DATA sec_connection     TYPE abap_bool.
@@ -148,9 +149,13 @@ CLASS zcl_logger DEFINITION
         VALUE(detailed_msg) TYPE bal_s_msg.
     METHODS add_bapi_status_result
       IMPORTING
-        !obj_to_log         TYPE any
+         obj_to_log         TYPE any
       RETURNING
         VALUE(detailed_msg) TYPE bal_s_msg.
+    METHODS add_exception
+      IMPORTING
+        i_s_exc TYPE bal_s_exc
+      RETURNING VALUE(c_s_msg) TYPE bal_s_msg.
 ENDCLASS.
 
 
@@ -372,7 +377,9 @@ CLASS zcl_logger IMPLEMENTATION.
 
 
   METHOD get_struct_kind.
-    DATA: msg_struct_kind   TYPE REF TO cl_abap_structdescr,
+    DATA: ddic_header type x030l,
+          structure_name type tabname,
+          msg_struct_kind   TYPE REF TO cl_abap_structdescr,
           components        TYPE abap_compdescr_tab,
           component         LIKE LINE OF components,
           syst_count        TYPE i,
@@ -387,6 +394,15 @@ CLASS zcl_logger IMPLEMENTATION.
         OR msg_type->type_kind = cl_abap_typedescr=>typekind_struct2.
 
       msg_struct_kind ?= msg_type.
+
+      if msg_type->is_ddic_type( ).
+        ddic_header = msg_type->get_ddic_header( ).
+        if ddic_header-tabname = 'BAL_S_MSG'.
+          result = c_struct_kind-application_log.
+          return.
+        endif.
+      endif.
+
       components = msg_struct_kind->components.
 
       " Count number of fields expected for each supported type of message structure
@@ -622,6 +638,8 @@ CLASS zcl_logger IMPLEMENTATION.
       detailed_msg = add_bapi_meth_msg( obj_to_log ).
     ELSEIF struct_kind = c_struct_kind-bapi_status_result.
       detailed_msg = add_bapi_status_result( obj_to_log ).
+    elseif struct_kind = c_struct_kind-application_log.
+      detailed_msg = obj_to_log.
     ELSEIF msg_type->type_kind = cl_abap_typedescr=>typekind_oref.
       TRY.
           "BEGIN this could/should be moved into its own method
@@ -719,14 +737,19 @@ CLASS zcl_logger IMPLEMENTATION.
     ELSEIF exception_data_table IS NOT INITIAL.
       FIELD-SYMBOLS <exception_data> LIKE LINE OF exception_data_table.
       LOOP AT exception_data_table ASSIGNING <exception_data>.
-        CALL FUNCTION 'BAL_LOG_EXCEPTION_ADD'
-          EXPORTING
-            i_log_handle = me->handle
-            i_s_exc      = <exception_data>.
+        detailed_msg = add_exception( <exception_data> ).
+        zif_logger~add(
+              obj_to_log    = detailed_msg
+              context       = context
+              importance    = importance
+              type          = type
+              detlevel      = detlevel ).
       ENDLOOP.
     ELSEIF detailed_msg IS NOT INITIAL.
       detailed_msg-context   = formatted_context.
-      detailed_msg-params    = formatted_params.
+      if detailed_msg-params is INITIAL.
+        detailed_msg-params = formatted_params.
+      endif.
       detailed_msg-probclass = importance.
       detailed_msg-detlevel  = detlevel.
       IF type IS NOT INITIAL.
@@ -1025,4 +1048,97 @@ CLASS zcl_logger IMPLEMENTATION.
       importance          = importance
       detlevel            = detlevel ).
   ENDMETHOD.
+
+  METHOD add_exception.
+
+    "More or less the same code as in form exception_into_msg include LSBALF26
+
+    CONSTANTS: const_freetext_msgid   TYPE symsgid           VALUE 'BL',
+               const_exception_msgno  TYPE symsgno           VALUE '003',
+               const_exc_indicator(3) TYPE c                 VALUE '%_E'.
+
+    DATA: l_exception_description TYPE REF TO cl_instance_description,
+          l_class_id              TYPE seovalue,
+          l_cmpname               TYPE seocmpname,
+          l_t100key               TYPE scx_t100key,
+          l_textid                TYPE sotr_conc,
+          l_substitution_table    TYPE sotr_params,
+          l_param    TYPE sotr_param-param.
+
+    FIELD-SYMBOLS:
+           <l_substitution>       TYPE sotr_param.
+
+    DEFINE lmacro_get_message_variables.
+      IF NOT  l_t100key-attr&1 IS INITIAL.
+        l_param = l_t100key-attr&1.
+        READ TABLE l_substitution_table ASSIGNING <l_substitution>
+                                        WITH KEY param =  l_param.
+        IF sy-subrc IS INITIAL.
+          IF NOT <l_substitution>-value IS INITIAL.
+            c_s_msg-msgv&1 =  <l_substitution>-value.       "#EC *
+          ENDIF.
+        ENDIF.
+      ENDIF.
+    END-OF-DEFINITION.
+
+* get the parameter for text switching
+    CALL METHOD cl_message_helper=>get_text_params
+      EXPORTING
+        obj    = i_s_exc-exception
+      IMPORTING
+        params = l_substitution_table.
+
+* exception -> type OTR-message or T100-message?
+    CALL METHOD cl_message_helper=>check_msg_kind
+      EXPORTING
+        msg     = i_s_exc-exception
+      IMPORTING
+        t100key = l_t100key
+        textid  = l_textid.
+
+    IF l_textid IS NOT INITIAL.
+
+* get name of exception class
+      CREATE OBJECT l_exception_description
+        EXPORTING
+          the_subject = i_s_exc-exception.
+
+* get text for textid
+      CONCATENATE '''' i_s_exc-exception->textid '''' INTO l_class_id.
+      SELECT cmpname
+      FROM seocompodf UP TO 1 rows
+      INTO l_cmpname
+        WHERE clsname = l_exception_description->class_name
+        AND attvalue  = l_class_id.
+      ENDSELECT.
+*   fill basic data of message
+*   message variables are used to store:
+*    - exception class (msgv1)
+*    - OTR guid        (msgv2)
+*    - text for guid   (msgv3)
+*    - flag to indicate exception (msgv4)
+      c_s_msg-msgid     = const_freetext_msgid.
+      c_s_msg-msgno     = const_exception_msgno.
+      c_s_msg-msgv1     = l_exception_description->class_name.
+      c_s_msg-msgv2     = i_s_exc-exception->textid.
+      c_s_msg-msgv3     = l_cmpname.
+      c_s_msg-msgv4     = const_exc_indicator.
+    ELSEIF NOT l_t100key IS INITIAL.
+*   exception with T100 message
+      c_s_msg-msgid     = l_t100key-msgid.
+      c_s_msg-msgno     = l_t100key-msgno.
+      lmacro_get_message_variables 1.
+      lmacro_get_message_variables 2.
+      lmacro_get_message_variables 3.
+      lmacro_get_message_variables 4.
+    ENDIF.
+
+    c_s_msg-msgty     = i_s_exc-msgty.
+    c_s_msg-probclass = i_s_exc-probclass.
+    c_s_msg-detlevel  = i_s_exc-detlevel.
+    c_s_msg-time_stmp = i_s_exc-time_stmp.
+    c_s_msg-alsort    = i_s_exc-alsort.
+
+  ENDMETHOD.
+
 ENDCLASS.

--- a/src/zcl_logger.clas.testclasses.abap
+++ b/src/zcl_logger.clas.testclasses.abap
@@ -1940,12 +1940,12 @@ CLASS lcl_test IMPLEMENTATION.
 
   METHOD can_log_exception_with_context.
 
-    DATA: exception    TYPE REF TO lcx_t100,
-          msg_handle   TYPE balmsghndl,
+    DATA: exception        TYPE REF TO lcx_t100,
+          msg_handle       TYPE balmsghndl,
           actual_details   TYPE bal_s_msg,
           expected_details TYPE bal_s_msg,
-          exp_callback TYPE bal_s_clbk,
-          addl_context TYPE bezei20 VALUE 'Berlin'.
+          exp_callback     TYPE bal_s_clbk,
+          addl_context     TYPE bezei20 VALUE 'Berlin'.
 
     "Given
     exp_callback-userexitf = 'FORM'.
@@ -1984,8 +1984,6 @@ CLASS lcl_test IMPLEMENTATION.
       IMPORTING
         e_s_msg        = actual_details.
 
-    clear: actual_details-msg_count, actual_details-time_stmp.
-
     cl_abap_unit_assert=>assert_equals(
       exp = exp_callback
       act = actual_details-params-callback
@@ -2001,7 +1999,7 @@ CLASS lcl_test IMPLEMENTATION.
       act = actual_details-context-tabname
       msg = 'Did not add context correctly' ).
 
-    clear: actual_details-msg_count, actual_details-time_stmp,
+    CLEAR: actual_details-msg_count, actual_details-time_stmp,
            actual_details-context, actual_details-params.
 
     cl_abap_unit_assert=>assert_equals(

--- a/src/zcl_logger.clas.testclasses.abap
+++ b/src/zcl_logger.clas.testclasses.abap
@@ -99,7 +99,8 @@ CLASS lcl_test DEFINITION FOR TESTING
       can_log_bapi_alm_return FOR TESTING,
       can_log_bapi_meth_message FOR TESTING RAISING cx_static_check,
       can_log_bapi_status_result FOR TESTING RAISING cx_static_check,
-      can_log_detlevel FOR TESTING RAISING cx_static_check.
+      can_log_detlevel FOR TESTING RAISING cx_static_check,
+      can_log_exception_with_context FOR TESTING RAISING cx_static_check.
 
 ENDCLASS.
 
@@ -1934,6 +1935,79 @@ CLASS lcl_test IMPLEMENTATION.
         act = <detail>-detlevel ).
 
     ENDLOOP.
+
+  ENDMETHOD.
+
+  METHOD can_log_exception_with_context.
+
+    DATA: exception    TYPE REF TO lcx_t100,
+          msg_handle   TYPE balmsghndl,
+          actual_details   TYPE bal_s_msg,
+          expected_details TYPE bal_s_msg,
+          exp_callback TYPE bal_s_clbk,
+          addl_context TYPE bezei20 VALUE 'Berlin'.
+
+    "Given
+    exp_callback-userexitf = 'FORM'.
+    exp_callback-userexitp = 'PROGRAM'.
+    exp_callback-userexitt = ' '.
+
+    expected_details-msgty = 'E'.
+    expected_details-msgid = 'SABP_UNIT'.
+    expected_details-msgno = '000'.
+    expected_details-msgv1 = 'This'.
+    expected_details-msgv2 = 'is'.
+    expected_details-msgv3 = 'a'.
+    expected_details-msgv4 = 'test'.
+
+    CREATE OBJECT exception
+      EXPORTING
+        id    = 'SABP_UNIT'
+        no    = '000'
+        msgv1 = 'This'
+        msgv2 = 'is'
+        msgv3 = 'a'
+        msgv4 = 'test'.
+
+    "When
+    anon_log->add( obj_to_log = exception
+                   callback_form = 'FORM'
+                   callback_prog = 'PROGRAM'
+                   context =  addl_context ).
+
+    msg_handle-log_handle = anon_log->handle.
+    msg_handle-msgnumber  = '000001'.
+
+    CALL FUNCTION 'BAL_LOG_MSG_READ'
+      EXPORTING
+        i_s_msg_handle = msg_handle
+      IMPORTING
+        e_s_msg        = actual_details.
+
+    clear: actual_details-msg_count, actual_details-time_stmp.
+
+    cl_abap_unit_assert=>assert_equals(
+      exp = exp_callback
+      act = actual_details-params-callback
+      msg = 'Did not add callback correctly' ).
+
+    cl_abap_unit_assert=>assert_equals(
+      exp = addl_context
+      act = actual_details-context-value
+      msg = 'Did not add context correctly' ).
+
+    cl_abap_unit_assert=>assert_equals(
+      exp = 'BEZEI20'
+      act = actual_details-context-tabname
+      msg = 'Did not add context correctly' ).
+
+    clear: actual_details-msg_count, actual_details-time_stmp,
+           actual_details-context, actual_details-params.
+
+    cl_abap_unit_assert=>assert_equals(
+      exp = expected_details
+      act = actual_details
+      msg = 'Did not log system message properly' ).
 
   ENDMETHOD.
 

--- a/src/zcl_logger.clas.testclasses.abap
+++ b/src/zcl_logger.clas.testclasses.abap
@@ -75,6 +75,7 @@ CLASS lcl_test DEFINITION FOR TESTING
       can_log_rcomp     FOR TESTING,
       can_log_prott FOR TESTING,
       can_log_sprot FOR TESTING,
+      can_log_bal_s_msg FOR TESTING,
       can_log_bapirettab FOR TESTING,
       can_log_err FOR TESTING,
       can_log_chained_exceptions FOR TESTING,
@@ -741,6 +742,56 @@ CLASS lcl_test IMPLEMENTATION.
     expected_details-msgv4 = sprot_msg-var4 = 'test'.
 
     anon_log->add( sprot_msg ).
+
+    msg_handle-log_handle = anon_log->handle.
+    msg_handle-msgnumber  = '000001'.
+
+    CALL FUNCTION 'BAL_LOG_MSG_READ'
+      EXPORTING
+        i_s_msg_handle = msg_handle
+      IMPORTING
+        e_s_msg        = actual_details
+        e_txt_msg      = actual_text.
+
+    cl_abap_unit_assert=>assert_not_initial(
+      act = actual_details-time_stmp
+      msg = 'Did not log system message properly' ).
+
+    expected_details-msg_count = 1.
+    CLEAR actual_details-time_stmp.
+
+    cl_abap_unit_assert=>assert_equals(
+      exp = expected_details
+      act = actual_details
+      msg = 'Did not log system message properly' ).
+    cl_abap_unit_assert=>assert_equals(
+      exp = 'This is a test'
+      act = condense( actual_text )
+      msg = 'Did not log system message properly' ).
+    cl_abap_unit_assert=>assert_equals(
+      exp = abap_true
+      act = anon_log->has_warnings( )
+      msg = 'Did not log or fetch system message properly' ).
+  ENDMETHOD.
+
+  METHOD can_log_bal_s_msg.
+    DATA: bal_s_msg        TYPE bal_s_msg,
+          msg_handle       TYPE balmsghndl,
+          expected_details TYPE bal_s_msg,
+          actual_details   TYPE bal_s_msg,
+          actual_text      TYPE char200.
+
+    bal_s_msg-msgty = 'W'.
+    bal_s_msg-msgid = 'BL'.
+    bal_s_msg-msgno = '001'.
+    bal_s_msg-msgv1 = 'This'.
+    bal_s_msg-msgv2 = 'is'.
+    bal_s_msg-msgv3 = 'a'.
+    bal_s_msg-msgv4 = 'test'.
+
+    expected_details = bal_s_msg.
+
+    anon_log->add( bal_s_msg ).
 
     msg_handle-log_handle = anon_log->handle.
     msg_handle-msgnumber  = '000001'.


### PR DESCRIPTION
Made it possible to add:

1. Structure of type BAL_S_MSG to log. 
2. Exception with context to the log. Was also possible to call add() with both parameters but context was not save in the log. 
