### PR TITLE
Use variable from settings

### DIFF
--- a/src/zcl_logger.clas.abap
+++ b/src/zcl_logger.clas.abap
@@ -75,8 +75,6 @@ CLASS zcl_logger DEFINITION
         bapi_status_result TYPE i VALUE 7,
       END OF c_struct_kind.
 
-    DATA sec_connection     TYPE abap_bool.
-    DATA sec_connect_commit TYPE abap_bool.
     DATA settings           TYPE REF TO zif_logger_settings.
 
     METHODS:
@@ -556,8 +554,8 @@ CLASS zcl_logger IMPLEMENTATION.
     CALL FUNCTION 'BAL_DB_SAVE'
       EXPORTING
         i_t_log_handle       = log_handles
-        i_2th_connection     = me->sec_connection
-        i_2th_connect_commit = me->sec_connect_commit
+        i_2th_connection     = me->settings->get_usage_of_secondary_db_conn( )
+        i_2th_connect_commit = me->settings->get_usage_of_secondary_db_conn( )
       IMPORTING
         e_new_lognumbers     = log_numbers.
     IF me->db_number IS INITIAL.

--- a/src/zcl_logger.clas.abap
+++ b/src/zcl_logger.clas.abap
@@ -549,13 +549,16 @@ CLASS zcl_logger IMPLEMENTATION.
     DATA log_handles TYPE bal_t_logh.
     DATA log_numbers TYPE bal_t_lgnm.
     DATA log_number  TYPE bal_s_lgnm.
+    DATA secondary_db_conn TYPE flag.
+    secondary_db_conn = me->settings->get_usage_of_secondary_db_conn( ).
 
     INSERT me->handle INTO TABLE log_handles.
+
     CALL FUNCTION 'BAL_DB_SAVE'
       EXPORTING
         i_t_log_handle       = log_handles
-        i_2th_connection     = me->settings->get_usage_of_secondary_db_conn( )
-        i_2th_connect_commit = me->settings->get_usage_of_secondary_db_conn( )
+        i_2th_connection     = secondary_db_conn
+        i_2th_connect_commit = secondary_db_conn
       IMPORTING
         e_new_lognumbers     = log_numbers.
     IF me->db_number IS INITIAL.

--- a/src/zcl_logger_factory.clas.abap
+++ b/src/zcl_logger_factory.clas.abap
@@ -115,13 +115,6 @@ CLASS zcl_logger_factory IMPLEMENTATION.
       lo_log->settings->set_autosave( abap_false ).
     ENDIF.
 
-    " Use secondary database connection to write data to database even if
-    " main program does a rollback (e. g. during a dump).
-    IF lo_log->settings->get_usage_of_secondary_db_conn( ) = abap_true.
-      lo_log->sec_connection     = abap_true.
-      lo_log->sec_connect_commit = abap_true.
-    ENDIF.
-
     " Set deletion date and set if log can be deleted before deletion date is reached.
     lo_log->header-aldate_del = lo_log->settings->get_expiry_date( ).
     lo_log->header-del_before = lo_log->settings->get_must_be_kept_until_expiry( ).


### PR DESCRIPTION
Fix for  #169.

I think this variable should be simply read from settings, instead of being another attribute with duplicate responsibility.