### PR TITLE
Error BL201 when calling free on a logger without object

### DIFF
--- a/src/zcl_logger.clas.abap
+++ b/src/zcl_logger.clas.abap
@@ -998,7 +998,7 @@ CLASS zcl_logger IMPLEMENTATION.
 
   METHOD zif_logger~free.
 
-    " Save any messages (safety) only if an object has been defined 
+    " Save any messages (safety) only if an object has been defined
     IF me->header-object IS NOT INITIAL.
       zif_logger~save( ).
     ENDIF.

--- a/src/zcl_logger.clas.abap
+++ b/src/zcl_logger.clas.abap
@@ -998,8 +998,10 @@ CLASS zcl_logger IMPLEMENTATION.
 
   METHOD zif_logger~free.
 
-    " Save any messages (safety)
-    zif_logger~save( ).
+    " Save any messages (safety) only if an object has been defined 
+    IF me->header-object IS NOT INITIAL.
+      zif_logger~save( ).
+    ENDIF.
 
     " Clear log from memory
     CALL FUNCTION 'BAL_LOG_REFRESH'


### PR DESCRIPTION
If a logger has no object, when calling method free, SAP tries to save nevertheless and it returns an error message BL201 _Log cannot be saved: Object/subobject not specified_

Test case
```ABAP
data g_logger type ref to zif_logger.
g_logger = zcl_logger_factory=>create_log( ).
g_logger->free( ).
```
