### PR TITLE
Don't log system message when table or structure is empty

### DIFF
--- a/src/zcl_logger.clas.abap
+++ b/src/zcl_logger.clas.abap
@@ -768,8 +768,6 @@ CLASS zcl_logger IMPLEMENTATION.
           type          = type
           importance    = importance
           detlevel      = detlevel ).
-    ELSEIF obj_to_log IS INITIAL.
-      detailed_msg = add_syst_msg( syst_buffer ).
     ELSE.
       free_text_msg = obj_to_log.
     ENDIF.

--- a/src/zcl_logger.clas.abap
+++ b/src/zcl_logger.clas.abap
@@ -160,7 +160,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_logger IMPLEMENTATION.
+CLASS ZCL_LOGGER IMPLEMENTATION.
 
 
   METHOD add_bapi_alm_msg.
@@ -636,7 +636,6 @@ CLASS zcl_logger IMPLEMENTATION.
           "these objects could be moved into their own method
           "see adt://***/sap/bc/adt/oo/classes/zcl_logger/source/main#start=391,10;end=415,61
           symsg                    TYPE symsg,
-          syst_buffer              TYPE syst,
           loggable                 TYPE REF TO zif_loggable_object,
           loggable_object_messages TYPE zif_loggable_object=>tty_messages.
 
@@ -646,7 +645,6 @@ CLASS zcl_logger IMPLEMENTATION.
                    <loggable_object_message> TYPE zif_loggable_object=>ty_message.
 
     " Remember system message since it might get changed inadvertently
-    syst_buffer = syst.
     IF context IS NOT INITIAL.
       ASSIGN context TO <context_val>.
       formatted_context-value = <context_val>.

--- a/src/zcl_logger.clas.abap
+++ b/src/zcl_logger.clas.abap
@@ -679,9 +679,7 @@ CLASS zcl_logger IMPLEMENTATION.
     msg_type    = cl_abap_typedescr=>describe_by_data( obj_to_log ).
     struct_kind = get_struct_kind( msg_type ).
 
-    IF obj_to_log IS INITIAL.
-      detailed_msg = add_syst_msg( syst_buffer ).
-    ELSEIF struct_kind = c_struct_kind-syst.
+    IF struct_kind = c_struct_kind-syst.
       detailed_msg = add_syst_msg( obj_to_log ).
     ELSEIF struct_kind = c_struct_kind-bapi.
       detailed_msg = add_bapi_msg( obj_to_log ).
@@ -770,6 +768,8 @@ CLASS zcl_logger IMPLEMENTATION.
           type          = type
           importance    = importance
           detlevel      = detlevel ).
+    ELSEIF obj_to_log IS INITIAL.
+      detailed_msg = add_syst_msg( syst_buffer ).
     ELSE.
       free_text_msg = obj_to_log.
     ENDIF.

--- a/src/zcl_logger.clas.testclasses.abap
+++ b/src/zcl_logger.clas.testclasses.abap
@@ -100,7 +100,9 @@ CLASS lcl_test DEFINITION FOR TESTING
       can_log_bapi_meth_message FOR TESTING RAISING cx_static_check,
       can_log_bapi_status_result FOR TESTING RAISING cx_static_check,
       can_log_detlevel FOR TESTING RAISING cx_static_check,
-      can_log_exception_with_context FOR TESTING RAISING cx_static_check.
+      can_log_exception_with_context FOR TESTING RAISING cx_static_check,
+      no_log_entry_for_empty_table FOR TESTING RAISING cx_static_check,
+      no_log_entry_for_empty_struct FOR TESTING RAISING cx_static_check.
 
 ENDCLASS.
 
@@ -2007,6 +2009,28 @@ CLASS lcl_test IMPLEMENTATION.
       act = actual_details
       msg = 'Did not log system message properly' ).
 
+  ENDMETHOD.
+
+  METHOD no_log_entry_for_empty_table.
+    DATA bapi_msg TYPE TABLE OF bapiret2.
+
+    MESSAGE i001(bl) INTO DATA(where_used_list)
+            WITH 'This should' '*not*' 'be logged'.
+
+    anon_log->add( bapi_msg ).
+    cl_abap_unit_assert=>assert_equals( act = anon_log->length( )
+                                        exp = 0 ).
+  ENDMETHOD.
+
+  METHOD no_log_entry_for_empty_struct.
+    DATA bapi_msg TYPE bapiret2.
+
+    MESSAGE i001(bl) INTO DATA(where_used_list)
+            WITH 'This should' '*not*' 'be logged'.
+
+    anon_log->add( bapi_msg ).
+    cl_abap_unit_assert=>assert_equals( act = anon_log->length( )
+                                        exp = 0 ).
   ENDMETHOD.
 
 ENDCLASS.

--- a/src/zcl_logger.clas.testclasses.abap
+++ b/src/zcl_logger.clas.testclasses.abap
@@ -101,7 +101,7 @@ CLASS lcl_test DEFINITION FOR TESTING
       can_log_bapi_status_result FOR TESTING RAISING cx_static_check,
       can_log_detlevel FOR TESTING RAISING cx_static_check,
       can_log_exception_with_context FOR TESTING RAISING cx_static_check,
-      symsg_not_logged_for_empty_obj FOR TESTING RAISING cx_static_check.
+      nothing_logged_for_empty_obj FOR TESTING RAISING cx_static_check.
 
 ENDCLASS.
 
@@ -2010,16 +2010,22 @@ CLASS lcl_test IMPLEMENTATION.
 
   ENDMETHOD.
 
-  METHOD symsg_not_logged_for_empty_obj.
+  METHOD nothing_logged_for_empty_obj.
     DATA where_used_list TYPE bapiret2-message ##NEEDED.
     DATA bapi_msgs TYPE TABLE OF bapiret2.
     DATA bapi_msg TYPE bapiret2.
 
     MESSAGE i001(bl) INTO where_used_list
             WITH 'This should' '*not*' 'be logged'.
+    CLEAR where_used_list.
 
     anon_log->add( bapi_msgs ).
+    cl_abap_unit_assert=>assert_equals( act = anon_log->length( )
+                                        exp = 0 ).
     anon_log->add( bapi_msg ).
+    cl_abap_unit_assert=>assert_equals( act = anon_log->length( )
+                                        exp = 0 ).
+    anon_log->add( where_used_list ).
     cl_abap_unit_assert=>assert_equals( act = anon_log->length( )
                                         exp = 0 ).
   ENDMETHOD.

--- a/src/zcl_logger.clas.testclasses.abap
+++ b/src/zcl_logger.clas.testclasses.abap
@@ -2011,7 +2011,7 @@ CLASS lcl_test IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD symsg_not_logged_for_empty_obj.
-    DATA where_used_list TYPE bapiret2-message ##needed.
+    DATA where_used_list TYPE bapiret2-message ##NEEDED.
     DATA bapi_msgs TYPE TABLE OF bapiret2.
     DATA bapi_msg TYPE bapiret2.
 

--- a/src/zcl_logger.clas.testclasses.abap
+++ b/src/zcl_logger.clas.testclasses.abap
@@ -101,8 +101,7 @@ CLASS lcl_test DEFINITION FOR TESTING
       can_log_bapi_status_result FOR TESTING RAISING cx_static_check,
       can_log_detlevel FOR TESTING RAISING cx_static_check,
       can_log_exception_with_context FOR TESTING RAISING cx_static_check,
-      no_log_entry_for_empty_table FOR TESTING RAISING cx_static_check,
-      no_log_entry_for_empty_struct FOR TESTING RAISING cx_static_check.
+      symsg_not_logged_for_empty_obj FOR TESTING RAISING cx_static_check.
 
 ENDCLASS.
 
@@ -2011,23 +2010,15 @@ CLASS lcl_test IMPLEMENTATION.
 
   ENDMETHOD.
 
-  METHOD no_log_entry_for_empty_table.
-    DATA bapi_msg TYPE TABLE OF bapiret2.
-
-    MESSAGE i001(bl) INTO DATA(where_used_list)
-            WITH 'This should' '*not*' 'be logged'.
-
-    anon_log->add( bapi_msg ).
-    cl_abap_unit_assert=>assert_equals( act = anon_log->length( )
-                                        exp = 0 ).
-  ENDMETHOD.
-
-  METHOD no_log_entry_for_empty_struct.
+  METHOD symsg_not_logged_for_empty_obj.
+    DATA where_used_list TYPE bapiret2-message ##needed.
+    DATA bapi_msgs TYPE TABLE OF bapiret2.
     DATA bapi_msg TYPE bapiret2.
 
-    MESSAGE i001(bl) INTO DATA(where_used_list)
+    MESSAGE i001(bl) INTO where_used_list
             WITH 'This should' '*not*' 'be logged'.
 
+    anon_log->add( bapi_msgs ).
     anon_log->add( bapi_msg ).
     cl_abap_unit_assert=>assert_equals( act = anon_log->length( )
                                         exp = 0 ).

--- a/src/zif_logger.intf.abap
+++ b/src/zif_logger.intf.abap
@@ -7,7 +7,7 @@ INTERFACE zif_logger
 
   METHODS add
     IMPORTING
-      obj_to_log          TYPE any OPTIONAL
+      obj_to_log          TYPE any DEFAULT sy
       context             TYPE any OPTIONAL
       callback_form       TYPE csequence OPTIONAL
       callback_prog       TYPE csequence OPTIONAL
@@ -22,7 +22,7 @@ INTERFACE zif_logger
 
   METHODS a
     IMPORTING
-      obj_to_log          TYPE any OPTIONAL
+      obj_to_log          TYPE any DEFAULT sy
       context             TYPE any OPTIONAL
       callback_form       TYPE csequence OPTIONAL
       callback_prog       TYPE csequence OPTIONAL
@@ -36,7 +36,7 @@ INTERFACE zif_logger
 
   METHODS e
     IMPORTING
-      obj_to_log          TYPE any OPTIONAL
+      obj_to_log          TYPE any DEFAULT sy
       context             TYPE any OPTIONAL
       callback_form       TYPE csequence OPTIONAL
       callback_prog       TYPE csequence OPTIONAL
@@ -50,7 +50,7 @@ INTERFACE zif_logger
 
   METHODS w
     IMPORTING
-      obj_to_log          TYPE any OPTIONAL
+      obj_to_log          TYPE any DEFAULT sy
       context             TYPE any OPTIONAL
       callback_form       TYPE csequence OPTIONAL
       callback_prog       TYPE csequence OPTIONAL
@@ -64,7 +64,7 @@ INTERFACE zif_logger
 
   METHODS i
     IMPORTING
-      obj_to_log          TYPE any OPTIONAL
+      obj_to_log          TYPE any DEFAULT sy
       context             TYPE any OPTIONAL
       callback_form       TYPE csequence OPTIONAL
       callback_prog       TYPE csequence OPTIONAL
@@ -78,7 +78,7 @@ INTERFACE zif_logger
 
   METHODS s
     IMPORTING
-      obj_to_log          TYPE any OPTIONAL
+      obj_to_log          TYPE any DEFAULT sy
       context             TYPE any OPTIONAL
       callback_form       TYPE csequence OPTIONAL
       callback_prog       TYPE csequence OPTIONAL


### PR DESCRIPTION
Check if object to log is initial after all the other checks. Simply moving the check seems to solve the problem. At least there are no regressions in the unit tests, and the two new tests pass as well.

Solved #168 